### PR TITLE
[WIP] Continue working on top declarations parsing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@
 compile_commands.json
 .cache
 .vscode
+.release
+__pycache__
+bin
+addcopyright.sh

--- a/gram/config.py
+++ b/gram/config.py
@@ -1,0 +1,1989 @@
+#
+# MIT License
+# Copyright (c) 2023 mxlol233 (mxlol233@outlook.com)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+sp_tokens = {
+    "`this`":None,
+    "`(`":None,
+    "`)`":None,
+    "`~`":None,
+    "`::`":None,
+    "`<`":None,
+    "`>`":None,
+    "`[`":None,
+    "`]`":None,
+    "`,`":None,
+    "`&`":None,
+    "`=`":None,
+    "`...`[opt]":None,
+    "`*`":None,
+    "`...`":None,
+    "`+`":None,
+    "`-`":None,
+    "`/`":None,
+    "`%`":None,
+    "`^`":None,
+    "`|`":None,
+    "`<<`":None,
+    "`>>`":None,
+    "`+=`":None,
+    "`-=`":None,
+    "`*=`":None,
+    "`/=`":None,
+    "`%=`":None,
+    "`^=`":None,
+    "`&=`":None,
+    "`|=`":None,
+    "`<<=`":None,
+    "`>>=`":None,
+    "`==`":None,
+    "`!=`":None,
+    "`<=`":None,
+    "`>=`":None,
+    "`&&`":None,
+    "`||`":None,
+    "`.*`":None,
+    "`->*`":None,
+    "`requires`":None,
+    "`{`":None,
+    "`}`":None,
+    "`;`":None,
+    "`typename`":None,
+    "`noexcept`[opt]":None,
+    "`->`":None,
+    "`.`":None,
+    "`template`[opt]":None,
+    "`++`":None,
+    "`--`":None,
+    "`dynamic_cast`":None,
+    "`static_cast`":None,
+    "`reinterpret_cast`":None,
+    "`const_cast`":None,
+    "`typeid`":None,
+    "`sizeof`":None,
+    "`identifier`":None,
+    "`alignof`":None,
+    "`!`":None,
+    "`co_await`":None,
+    "`noexcept`":None,
+    "`::`[opt]":None,
+    "`new`":None,
+    "`delete`":None,
+    "`<=>`":None,
+    "`?`":None,
+    "`:`":None,
+    "`co_yield`":None,
+    "`throw`":None,
+    "`case`":None,
+    "`default`":None,
+    "`if`":None,
+    "`constexpr`[opt]":None,
+    "`else`":None,
+    "`switch`":None,
+    "`while`":None,
+    "`do`":None,
+    "`for`":None,
+    "`break`":None,
+    "`continue`":None,
+    "`return`":None,
+    "`goto`":None,
+    "`co_return`":None,
+    "`using`":None,
+    "`static_assert`":None,
+    "`string-literal`":None,
+    "`friend`":None,
+    "`typedef`":None,
+    "`constexpr`":None,
+    "`consteval`":None,
+    "`constinit`":None,
+    "`inline`":None,
+    "`static`":None,
+    "`thread_local`":None,
+    "`extern`":None,
+    "`mutable`":None,
+    "`virtual`":None,
+    "`explicit`":None,
+    "`template`":None,
+    "`char`":None,
+    "`char8_t`":None,
+    "`char16_t`":None,
+    "`char32_t`":None,
+    "`wchar_t`":None,
+    "`bool`":None,
+    "`short`":None,
+    "`int`":None,
+    "`long`":None,
+    "`signed`":None,
+    "`unsigned`":None,
+    "`float`":None,
+    "`double`":None,
+    "`void`":None,
+    "`decltype`":None,
+    "`auto`":None,
+    "`const`":None,
+    "`volatile`":None,
+    "`,`[opt]":None,
+    "`enum`":None,
+    "`class`":None,
+    "`struct`":None,
+    "`inline`[opt]":None,
+    "`namespace`":None,
+    "`typename`[opt]":None,
+    "`asm`":None,
+    "`alignas`":None,
+    "`module`":None,
+    "`export`":None,
+    "`import`":None,
+    "`private`":None,
+    "`final`":None,
+    "`union`":None,
+    "`override`":None,
+    "`0`":None,
+    "`operator`":None,
+    "`virtual`[opt]":None,
+    "`protected`":None,
+    "`public`":None,
+    "`new[]`":None,
+    "`delete[]`":None,
+    "`()`":None,
+    "`[]`":None,
+    "`concept`":None,
+    "`extern`[opt]":None,
+    "`try`":None,
+    "`catch`":None,
+    "`#`":None,
+    "`include`":None,
+    "`define`":None,
+    "`undef`":None,
+    "`line`":None,
+    "`error`":None,
+    "`pragma`":None,
+    "`ifdef`":None,
+    "`ifndef`":None,
+    "`elif`":None,
+    "`endif`":None,
+    "`defined`":None,
+    "`__has_include`":None,
+    "`__has_pp_attribute`":None,
+    "`export`[opt]":None,
+    "`__VA_PT__`":None,
+}
+
+gram_tree = {}
+
+gram_tree["translation-unit"] = [
+    ["declaration-seq[opt]"],
+    ["global-module-fragment[opt]", "module-declaration", "declaration-seq[opt]", "private-module-fragment[opt]"],
+]
+
+gram_tree["primary-expression"] = [
+    ["literal"],
+    ["`this`"],
+    ["`(`", "expression", "`)`"],
+    ["id-expression"],
+    ["lambda-expression"],
+    ["fold-expression"],
+    ["requires-expression"],
+]
+
+gram_tree["id-expression"] = [
+    ["unqualified-id"],
+    ["qualified-id"],
+]
+
+gram_tree["unqualified-id"] = [
+    ["identifier"],
+    ["operator-function-id"],
+    ["conversion-function-id"],
+    ["literal-operator-id"],
+    ["`~`", "type-name"],
+    ["`~`", "decltype-specifier"],
+    ["`~`", "template-id"],
+]
+
+gram_tree["qualified-id"] = [
+    "nested-name-specifier", "`template`[opt]", "unqualified-id"
+]
+
+gram_tree["nested-name-specifier"] = [
+    ["`::`"],
+    ["type-name", "`::`"],
+    ["namespace-name", "`::`"],
+    ["decltype-specifier", "`::`"],
+    ["nested-name-specifier","identifier", "`::`"],
+    ["nested-name-specifier","`template`[opt]", "`::`"],
+    ["simple-template-id", "`::`"],
+]
+
+gram_tree["lambda-expression"] = [
+    ["lambda-introducer", "lambda-declarator[opt]", "compound-statement"],
+    ["lambda-introducer", "`<`", "template-parameter-list", "`>`", "requires-clause[opt]", "lambda-declarator[opt]", "compound-statement"],
+]
+
+gram_tree["lambda-introducer"] = [
+    "`[`", "lambda-capture[opt]", "`]`"
+]
+
+gram_tree["lambda-declarator"] = [
+    ["`(`", "parameter-declaration-clause", "`)`", "decl-specifier-seq[opt]"],
+    ["noexcept-specifier[opt]", "attribute-specifier-seq[opt]", "trailing-return-type[opt]", "requires-clause[opt]"]
+]
+
+gram_tree["lambda-capture"] = [
+    ["capture-default"],
+    ["capture-list"],
+    ["capture-default", "`,`", "capture-list"],
+]
+
+gram_tree["capture-default"] = [
+    ["`&`"],
+    ["`=`"],
+]
+
+gram_tree["capture-list"] = [
+    ["capture"],
+    ["capture-list", "`,`", "capture"]
+]
+
+gram_tree["capture"] = [
+    ["simple-capture"],
+    ["init-capture"],
+]
+
+gram_tree["simple-capture"] = [
+    ["identifier", "`...`[opt]"],
+    ["`&`", "identifier", "`...`[opt]"],
+    ["`this`"],
+    ["`*`", "`this`"],
+]
+
+gram_tree["init-capture"] = [
+    ["`...`[opt]", "identifier", "initializer"],
+    ["`&`", "`...`[opt]", "identifier", "initializer"],
+]
+
+gram_tree["fold-expression"] = [
+    ["`(`", "cast-expression", "fold-operator", "`...`", "`)`"],
+    ["`(`", "`...`", "fold-operator", "cast-expression", "`)`"],
+    ["`(`", "cast-expression", "fold-operator", "`...`", "fold-operator", "cast-expression", "`)`"]
+]
+
+gram_tree["fold-operator"] = [
+    ["`+`"], ["`-`"], ["`*`"], ["`/`"], ["`%`"], ["`^`"], ["`&`"], ["`|`"], ["`<<`"], ["`>>`"],
+    ["`+=`"], ["`-=`"], ["`*=`"], ["`/=`"], ["`%=`"], ["`^=`"], ["`&=`"], ["`|=`"], ["`<<=`"], ["`>>=`"], ["`=`"],
+    ["`==`"], ["`!=`"], ["`<`"], ["`>`"], ["`<=`"], ["`>=`"], ["`&&`"], ["`||`"], ["`,`"], ["`.*`"], ["`->*`"]
+]
+
+gram_tree["requires-expression"] = [
+    "`requires`", "requirement-parameter-list[opt]", "requirement-body",
+]
+
+gram_tree["requirement-parameter-list"] = [
+    "`(`", "parameter-declaration-clause[opt]", "`)`",
+]
+
+gram_tree["requirement-body"] = [
+    "`{`", "requirement-seq", "`}`",
+]
+
+gram_tree["requirement-seq"] = [
+    ["requirement"],
+    ["requirement-seq", "requirement"],
+]
+
+gram_tree["requirement"] = [
+    ["simple-requirement"],
+    ["type-requirement"],
+    ["compound-requirement"],
+    ["nested-requirement"],
+]
+
+gram_tree["simple-requirement"] = [
+    "expression", "`;`"
+]
+
+gram_tree["type-requirement"] = [
+    "`typename`", "nested-name-specifier[opt]", "type-name", "`;`"
+]
+
+gram_tree["compound-requirement"] = [
+    "`{`", "expression", "`}`", "`noexcept`[opt]", "return-type-requirement[opt]", "`;`"
+]
+
+gram_tree["return-type-requirement"] = [
+    "`->`", "type-constraint"
+]
+
+gram_tree["nested-requirement"] = [
+    "`requires`", "constraint-expression", "`;`"
+]
+
+gram_tree["postfix-expression"] = [
+    ["primary-expression"],
+    ["postfix-expression", "`[`", "expr-or-braced-init-list", "`]`"],
+    ["postfix-expression", "`(`", "expression-list[opt]", "`)`"],
+    ["simple-type-specifier", "`(`", "expression-list[opt]", "`)`"],
+    ["typename-specifier", "`(`", "expression-list[opt]", "`)`"],
+    ["simple-type-specifier", "braced-init-list"],
+    ["typename-specifier", "braced-init-list"],
+    ["postfix-expression", "`.`", "`template`[opt]", "id-expression"],
+    ["postfix-expression", "`->`", "`template`[opt]", "id-expression"],
+    ["postfix-expression","`++`"],
+    ["postfix-expression","`--`"],
+    ["`dynamic_cast`", "`<`", "type-id", "`>`", "`(`", "expression", "`)`"],
+    ["`static_cast`", "`<`", "type-id", "`>`", "`(`", "expression", "`)`"],
+    ["`reinterpret_cast`", "`<`", "type-id", "`>`", "`(`", "expression", "`)`"],
+    ["`const_cast`", "`<`", "type-id", "`>`", "`(`", "expression", "`)`"],
+    ["`typeid`",  "`(`", "expression", "`)`"],
+    ["`typeid`",  "`(`", "type-id", "`)`"],
+]
+
+gram_tree["expression-list"] = [
+    "initializer-list"
+]
+
+gram_tree["unary-expression"] = [
+    ["postfix-expression"],
+    ["unary-operator", "cast-expression"],
+    ["`++`", "cast-expression"],
+    ["`--`", "cast-expression"],
+    ["await-expression"],
+    ["`sizeof`", "unary-expression"],
+    ["`sizeof`", "`(`", "type-id", "`)`"],
+    ["`sizeof`", "`...`", "`(`", "`identifier`", "`)`"],
+    ["`alignof`", "`(`", "type-id", "`)`"],
+    ["noexcept-expression"],
+    ["new-expression"],
+    ["delete-expression"],
+]
+
+gram_tree["unary-operator"] = [
+    ["`*`"], ["`&`"], ["`+`"], ["`-`"], ["`!`"], ["`~`"]
+]
+
+gram_tree["await-expression"] = [
+    "`co_await`", "cast-expression"
+]
+
+gram_tree["noexcept-expression"] = [
+    "`noexcept`", "`(`", "expression", "`)`"
+]
+
+gram_tree["new-expression"] = [
+    ["`::`[opt]", "`new`", "new-placement[opt]", "new-type-id", "new-initializer[opt]"],
+    ["`::`[opt]", "`new`", "new-placement[opt]", "`(`", "type-id", "`)`", "new-initializer[opt]"],
+]
+
+gram_tree["new-placement"] = [
+    "`(`", "expression-list", "`)`"
+]
+
+gram_tree["new-type-id"] = [
+    "type-specifier-seq", "new-declarator[opt]"
+]
+
+gram_tree['new-declarator'] = [
+    ["ptr-operator", "new-declarator[opt]"],
+    ["noptr-new-declarator"]
+]
+
+gram_tree["noptr-new-declarator"] = [
+    ["`[`", "expression[opt]", "`]`", "attribute-specifier-seq[opt]"],
+    ["noptr-new-declarator", "`[`", "constant-expression", "`]`", "attribute-specifier-seq[opt]"]
+]
+
+gram_tree["new-initializer"] = [
+    ["`(`", "expression-list[opt]", "`)`"],
+    ["braced-init-list"],
+]
+
+gram_tree["delete-expression"] = [
+    ["`::`[opt]", "`delete`", "cast-expression"],
+    ["`::`[opt]", "`delete`", "`[`", "`]`",  "cast-expression"],
+]
+
+gram_tree["cast-expression"] = [
+    ["unary-expression"],
+    ["`(`", "type-id", "`)`", "cast-expression"]
+]
+
+gram_tree['pm-expression'] = [
+    ["cast-expression"],
+    ["pm-expression", "`.*`", "cast-expression"],
+    ["pm-expression", "`->*`", "cast-expression"],
+]
+
+gram_tree["multiplicative-expression"] = [
+    ["pm-expression"],
+    ["multiplicative-expression", "`*`", "pm-expression"],
+    ["multiplicative-expression", "`/`", "pm-expression"],
+    ["multiplicative-expression", "`%`", "pm-expression"],
+]
+
+gram_tree["additive-expression"] = [
+    ["multiplicative-expression"],
+    ["additive-expression", "`+`", "multiplicative-expression"],
+    ["additive-expression", "`-`", "multiplicative-expression"]
+]
+
+gram_tree["shift-expression"] = [
+    ["additive-expression"],
+    ["shift-expression", "`<<`", "additive-expression"],
+    ["shift-expression", "`>>`", "additive-expression"],
+]
+
+gram_tree["compare-expression"] = [
+    ["shift-expression"],
+    ["compare-expression", "`<=>`", "shift-expression"],
+]
+
+gram_tree["relational-expression"] = [
+    ["compare-expression"],
+    ["relational-expression", "`<`", "compare-expression"],
+    ["relational-expression", "`>`",  "compare-expression"],
+    ["relational-expression", "`<=`",  "compare-expression"],
+    ["relational-expression", "`>=`",  "compare-expression"],
+]
+
+gram_tree["equality-expression"] = [
+    ["relational-expression"],
+    ["equality-expression", "`==`", "relational-expression"],
+    ["equality-expression", "`!=`", "relational-expression"]
+]
+
+gram_tree["and-expression"] = [
+    ["equality-expression"],
+    ["and-expression", "`&`", "equality-expression"]
+]
+
+gram_tree["exclusive-or-expression"] = [
+    ["and-expression"],
+    ["exclusive-or-expression", "`^`", "and-expression"],
+]
+
+gram_tree["inclusive-or-expression"] = [
+    ["exclusive-or-expression"],
+    ["inclusive-or-expression", "`|`", "exclusive-or-expression"],
+]
+
+gram_tree["logical-and-expression"] = [
+    ["inclusive-or-expression"],
+    ["logical-and-expression", "`&&`", "exclusive-or-expression"],
+]
+
+gram_tree["logical-or-expression"] = [
+    ["logical-and-expression"],
+    ["logical-or-expression", "`||`", "logical-and-expression"],
+]
+
+gram_tree["conditional-expression"] = [
+    ["logical-or-expression"],
+    ["logical-or-expression", "`?`", "expression", "`:`", "assignment-expression"]
+]
+
+gram_tree["yield-expression"] = [
+    ["`co_yield`", "assignment-expression"],
+    ["`co_yield`", "braced-init-list"],
+]
+
+gram_tree["throw-expression"] = [
+    ["`throw`", "assignment-expression[opt]"],
+]
+
+gram_tree["assignment-expression"] = [
+    ["conditional-expression"],
+    ["yield-expression"],
+    ["throw-expression"],
+    ["logical-or-expression", "assignment-operator", "initializer-clause"]
+]
+
+gram_tree["assignment-operator"] = [
+    ["`=`"], ["`*=`"], ["`/=`"], ["`%=`"], ["`+=`"], ["`-=`"], ["`>>=`"], ["`<<=`"], ["`&=`"], ["`^=`"], ["`|=`"]
+]
+
+gram_tree["expression"] = [
+    ["assignment-expression"],
+    ["expression", "`,`", "assignment-expression"],
+]
+
+gram_tree["constant-expression"] = [
+    "conditional-expression"
+]
+
+gram_tree["statement"] = [
+    ["labeled-statement"],
+    ["attribute-specifier-seq[opt]", "expression-statement"],
+    ["attribute-specifier-seq[opt]", "compound-statement"],
+    ["attribute-specifier-seq[opt]", "selection-statement"],
+    ["attribute-specifier-seq[opt]", "iteration-statement"],
+    ["attribute-specifier-seq[opt]", "jump-statement"],
+    ["declaration-statement"],
+    ["attribute-specifier-seq[opt]", "try-block"],
+]
+
+gram_tree["init-statement"] = [
+    ["expression-statement"],
+    ["simple-declaration"]
+]
+
+gram_tree["condition"] = [
+    ["expression"],
+    ["attribute-specifier-seq[opt]", "decl-specifier-seq", "declarator", "brace-or-equal-initializer"],
+]
+
+gram_tree["labeled-statement"] = [
+    ["attribute-specifier-seq[opt]", "identifier", "`:`", "statement"],
+    ["attribute-specifier-seq[opt]", "`case`","constant-expression", "`:`", "statement"],
+    ["attribute-specifier-seq[opt]", "`default`", "`:`", "statement"],
+]
+
+gram_tree["expression-statement"] = [
+    "expression[opt]", "`;`"
+]
+
+gram_tree["compound-statement"] = [
+    "`{`", "statement-seq[opt]", "`}`"
+]
+
+gram_tree["statement-seq"] = [
+    ["statement"],
+    ["statement-seq", "statement"],
+]
+
+gram_tree["selection-statement"] = [
+    ["`if`", "`constexpr`[opt]", "`(`", "init-statement[opt]","condition",  "`)`", "statement"],
+    ["`if`", "`constexpr`[opt]", "`(`", "init-statement[opt]","condition",  "`)`", "statement", "`else`", "statement"],
+    ["`switch`", "`(`", "init-statement[opt]","condition",  "`)`", "statement"],
+]
+
+gram_tree["iteration-statement"] = [
+    ["`while`", "`(`", "condition", "`)`", "statement"],
+    ["`do`", "statement", "`while`", "`(`", "expression", "`)`", "`;`"],
+    ["`for`", "`(`", "init-statement", "condition[opt]","`;`", "expression[opt]","`)`", "statement"],
+    ["`for`", "`(`", "init-statement[opt]", "for-range-declaration", "`:`", "for-range-initializer", "`)`", "statement"],
+]
+
+gram_tree["for-range-declaration"] = [
+    ["attribute-specifier-seq[opt]", "decl-specifier-seq", "declarator"],
+    ["attribute-specifier-seq[opt]", "decl-specifier-seq", "ref-qualifier[opt]", "`[`", "identifier-list", "`]`" ],
+]
+
+gram_tree["for-range-initializer"] = [
+    "expr-or-braced-init-list"
+]
+
+gram_tree["jump-statement"] = [
+    ["`break`", "`;`"],
+    ["`continue`", "`;`"],
+    ["`return`", "expr-or-braced-init-list[opt]", "`;`"],
+    ["coroutine-return-statement"],
+    ["`goto`", "identifier", "`;`"]
+]
+
+gram_tree["coroutine-return-statement"] = [
+    "`co_return`", "expr-or-braced-init-list[opt]", "`;`"
+]
+
+gram_tree["declaration-statement"] = [
+    "block-declaration"
+]
+
+gram_tree["declaration-seq"] = [
+    ["declaration"],
+    ["declaration-seq", "declaration"],
+]
+
+gram_tree["declaration"] = [
+    ["block-declaration"],
+    ["nodeclspec-function-declaration"],
+    ["function-definition"],
+    ["template-declaration"],
+    ["deduction-guide"],
+    ["explicit-instantiation"],
+    ["explicit-specialization"],
+    ["export-declaration"],
+    ["linkage-specification"],
+    ["namespace-definition"],
+    ["empty-declaration"],
+    ["attribute-declaration"],
+    ["module-import-declaration"],
+]
+
+gram_tree["block-declaration"] = [
+    ["simple-declaration"],
+    ["asm-declaration"],
+    ["namespace-alias-definition"],
+    ["using-declaration"],
+    ["using-enum-declaration"],
+    ["using-directive"],
+    ["static_assert-declaration"],
+    ["alias-declaration"],
+    ["opaque-enum-declaration"],
+]
+
+gram_tree["nodeclspec-function-declaration"] = [
+    "attribute-specifier-seq[opt]", "declarator", "`;`"
+]
+
+gram_tree["alias-declaration"] = [
+"`using`", "identifier",  "attribute-specifier-seq[opt]", "`=`", "defining-type-id", "`;`"
+]
+
+gram_tree["simple-declaration"] = [
+    ["decl-specifier-seq", "init-declarator-list[opt]", "`;`"],
+    ["attribute-specifier-seq", "decl-specifier-seq", "init-declarator-list", "`;`"],
+    ["attribute-specifier-seq[opt]", "decl-specifier-seq", "ref-qualifier[opt]", "`[`", "identifier-list", "`]`", "initializer", "`;`"]
+]
+
+gram_tree["static_assert-declaration"] = [
+    ["`static_­assert`", "`(`", "constant-expression", "`)`", "`;`"],
+    ["`static_­assert`", "`(`", "constant-expression", "`,`", "`string-literal`", "`)`", "`;`"]
+]
+
+gram_tree["empty-declaration"] = [
+    "`;`"
+]
+
+gram_tree["attribute-declaration"] = [
+    "attribute-specifier-seq", "`;`"
+]
+
+gram_tree["decl-specifier"] = [
+    ["storage-class-specifier"],
+    ["defining-type-specifier"],
+    ["function-specifier"],
+    ["`friend`"],
+    ["`typedef`"],
+    ["`constexpr`"],
+    ["`consteval`"],
+    ["`constinit`"],
+    ["`inline`"],
+]
+
+gram_tree["decl-specifier-seq"] = [
+    ["decl-specifier", "attribute-specifier-seq[opt]"],
+    ["decl-specifier", "decl-specifier-seq"],
+]
+
+gram_tree["storage-class-specifier"] = [
+    ["`static`"],
+    ["`thread_­local`"],
+    ["`extern`"],
+    ["`mutable`"],
+]
+
+gram_tree["function-specifier"] = [
+    ["`virtual`"],
+    ["explicit-specifier"]
+]
+
+gram_tree["explicit-specifier"] = [
+    ["`explicit`", "`(`", "constant-expression", "`)`"],
+    ["`explicit`"],
+]
+
+gram_tree["typedef-name"] = [
+    ["identifier"],
+    ["simple-template-id"],
+]
+
+gram_tree["type-specifier"] = [
+    ["simple-type-specifier"],
+    ["elaborated-type-specifier"],
+    ["typename-specifier"],
+    ["cv-qualifier"],
+]
+
+gram_tree["type-specifier-seq"] = [
+    ["type-specifier", "attribute-specifier-seq[opt]"],
+    ["type-specifier", "type-specifier-seq"],
+]
+
+gram_tree["defining-type-specifier"] = [
+    ["type-specifier"],
+    ["class-specifier"],
+    ["enum-specifier"],
+]
+
+gram_tree["defining-type-specifier-seq"] = [
+    ["defining-type-specifier", "attribute-specifier-seq[opt]"],
+    ["defining-type-specifier", "defining-type-specifier-seq"],
+]
+
+gram_tree["simple-type-specifier"] = [
+    ["nested-name-specifier[opt]", "type-name"],
+    ["nested-name-specifier", "`template`", "simple-template-id"],
+    ["decltype-specifier"],
+    ["placeholder-type-specifier"],
+    ["nested-name-specifier[opt]", "template-name"],
+    ["`char`"],
+    ["`char8_t`"],
+    ["`char16_t`"],
+    ["`char32_t`"],
+    ["`wchar_t`"],
+    ["`bool`"],
+    ["`short`"],
+    ["`int`"],
+    ["`long`"],
+    ["`signed`"],
+    ["`unsigned`"],
+    ["`float`"],
+    ["`double`"],
+    ["`void`"],
+]
+
+gram_tree["type-name"] = [
+    ["class-name"],
+    ["enum-name"],
+    ["typedef-name"],
+]
+
+gram_tree["elaborated-type-specifier"] = [
+    ["class-key", "attribute-specifier-seq[opt]", "nested-name-specifier[opt]", "identifier"],
+    ["class-key", "simple-template-id"],
+    ["class-key", "nested-name-specifier", "`template`[opt]", "simple-template-id"],
+    ["elaborated-enum-specifier"],
+]
+
+gram_tree["elaborated-enum-specifier"] = [
+    "`enum`", "nested-name-specifier[opt]", "identifier"
+]
+
+gram_tree["decltype-specifier"] = [
+"`decltype`", "`(`", "expression", "`)`"
+]
+
+gram_tree["placeholder-type-specifier"] = [
+    ["type-constraint[opt]", "`auto`"],
+    ["type-constraint[opt]", "`decltype`", "`(`", "`auto`", "`)`"],
+]
+
+gram_tree["init-declarator-list"] = [
+    ["init-declarator"],
+    ["init-declarator-list", "`,`", "init-declarator"],
+]
+
+gram_tree["init-declarator"] = [
+    ["declarator", "initializer[opt]"],
+    ["declarator", "requires-clause"],
+]
+
+gram_tree["declarator"] = [
+    ["ptr-declarator"],
+    ["noptr-declarator", "parameters-and-qualifiers", "trailing-return-type"],
+]
+
+gram_tree["ptr-declarator"] = [
+    ["noptr-declarator"],
+    ["ptr-operator", "ptr-declarator"],
+]
+
+gram_tree["noptr-declarator"] = [
+    ["declarator-id", "attribute-specifier-seq"],
+    ["noptr-declarator", "parameters-and-qualifiers"],
+    ["noptr-declarator", "`[`", "constant-expression[opt]", "`]`", "attribute-specifier-seq[opt]"],
+    ["`(`", "ptr-declarator", "`)`"],
+]
+
+gram_tree["parameters-and-qualifiers"] = [
+    ["`(`", "parameter-declaration-clause", "`)`", "cv-qualifier-seq[opt]"],
+    ["ref-qualifier[opt]", "noexcept-specifier[opt]", "attribute-specifier-seq[opt]"],
+]
+
+gram_tree["trailing-return-type"] = [
+    "`->`", "type-id",
+]
+
+gram_tree["ptr-operator"] = [
+    ["`*`", "attribute-specifier-seq[opt]", "cv-qualifier-seq[opt]"],
+    ["`&`", "attribute-specifier-seq[opt]"],
+    ["`&&`", "attribute-specifier-seq[opt]"],
+    ["nested-name-specifier", "`*`", "attribute-specifier-seq[opt]", "cv-qualifier-seq[opt]"],
+]
+
+gram_tree["cv-qualifier-seq"] = [
+   "cv-qualifier", "cv-qualifier-seq[opt]",
+]
+
+gram_tree["cv-qualifier"] = [
+    ["`const`"],
+    ["`volatile`"],
+]
+
+gram_tree["ref-qualifier"] = [
+    ["`&`"],
+    ["`&&`"],
+]
+
+gram_tree["declarator-id"] = [
+    "`...`[opt]", "id-expression",
+]
+
+gram_tree["type-id"] = [
+    "type-specifier-seq", "abstract-declarator[opt]",
+]
+
+gram_tree["defining-type-id"] = [
+    "defining-type-specifier-seq", "abstract-declarator[opt]"
+]
+
+gram_tree["abstract-declarator"] = [
+    ["ptr-abstract-declarator"],
+    ["noptr-abstract-declarator", "parameters-and-qualifiers", "trailing-return-type"],
+    ["abstract-pack-declarator"],
+]
+
+gram_tree["ptr-abstract-declarator"] = [
+    ["noptr-abstract-declarator"],
+    ["ptr-operator", "ptr-abstract-declarator"]
+]
+
+gram_tree["noptr-abstract-declarator"] = [
+    ["noptr-abstract-declarator[opt]", "parameters-and-qualifiers"],
+    ["noptr-abstract-declarator[opt]", "`[`", "constant-expression[opt]"  , "`]`", "attribute-specifier-seq[opt]"],
+    ["`(`", "ptr-abstract-declarator", "`)`"]
+]
+
+gram_tree["abstract-pack-declarator"] = [
+    ["noptr-abstract-pack-declarator"],
+    ["ptr-operator", "abstract-pack-declarator"],
+]
+
+gram_tree["noptr-abstract-pack-declarator"] = [
+    ["noptr-abstract-pack-declarator", "parameters-and-qualifiers"],
+    ["noptr-abstract-pack-declarator", "`[`", "constant-expression[opt]", "`]`", "attribute-specifier-seq[opt]"],
+    ["`...`"],
+]
+
+gram_tree["parameter-declaration-clause"] = [
+    ["parameter-declaration-list[opt]", "`...`[opt]"],
+    ["parameter-declaration-list", "`,`", "`...`"],
+]
+
+gram_tree["parameter-declaration-list"] = [
+    ["parameter-declaration"],
+    ["parameter-declaration-list", "`,`", "parameter-declaration"],
+]
+
+gram_tree["parameter-declaration"] = [
+    ["attribute-specifier-seq[opt]", "decl-specifier-seq", "declarator"],
+    ["attribute-specifier-seq[opt]", "decl-specifier-seq", "declarator", "`=`", "initializer-clause"],
+    ["attribute-specifier-seq[opt]", "decl-specifier-seq", "abstract-declarator[opt]"],
+    ["attribute-specifier-seq[opt]", "decl-specifier-seq", "abstract-declarator[opt]", "`=`", "initializer-clause"],
+]
+
+gram_tree["initializer"] = [
+    ["brace-or-equal-initializer"],
+    ["`(`", "expression-list", "`)`"],
+]
+
+gram_tree["brace-or-equal-initializer"] = [
+    ["`=`", "initializer-clause"],
+    ["braced-init-list"],
+]
+
+gram_tree["initializer-clause"] = [
+    ["assignment-expression"],
+    ["braced-init-list"],
+]
+
+gram_tree["braced-init-list"] = [
+    ["`{`", "initializer-list", "`,`[opt]", "`}`"],
+    ["`{`", "designated-initializer-list", "`,`[opt]", "`}`"],
+    ["`{`", "`}`"],
+]
+
+gram_tree["initializer-list"] = [
+    ["initializer-clause", "`...`[opt]"],
+    ["initializer-list", "`,`", "initializer-clause", "`...`[opt]"]
+]
+
+gram_tree["designated-initializer-list"] = [
+    ["designated-initializer-clause"],
+    ["designated-initializer-list", "`,`", "designated-initializer-clause"]
+]
+
+gram_tree["designated-initializer-clause"] = [
+    "designator", "brace-or-equal-initializer"
+]
+
+gram_tree["designator"] = [
+    "`.`", "identifier"
+]
+
+gram_tree["expr-or-braced-init-list"] = [
+    ["expression"],
+    ["braced-init-list"],
+]
+
+gram_tree["function-definition"] = [
+    ["attribute-specifier-seq[opt]","decl-specifier-seq[opt]", "declarator", "virt-specifier-seq[opt]", "function-body"],
+    ["attribute-specifier-seq[opt]","decl-specifier-seq[opt]", "declarator", "requires-clause", "function-body"],
+]
+
+gram_tree["function-body"] = [
+    ["ctor-initializer[opt]", "compound-statement"],
+    ["function-try-block"],
+    ["`=`", "`default`", "`;`"],
+    ["`=`", "`delete`", "`;`"],
+]
+
+gram_tree["enum-name"] = [
+    "identifier"
+]
+
+gram_tree["enum-specifier"] = [
+    ["enum-head", "`{`", "enumerator-list[opt]", "`}`"],
+    ["enum-head", "`{`", "enumerator-list", "`,`", "`}`"],
+]
+
+gram_tree["enum-head"] = [
+    "enum-key", "attribute-specifier-seq[opt]", "enum-head-name[opt]", "enum-base[opt]",
+]
+
+gram_tree["enum-head-name"] = [
+    "nested-name-specifier[opt]", "identifier"
+]
+
+gram_tree["opaque-enum-declaration"] = [
+    "enum-key", "attribute-specifier-seq[opt]", "enum-head-name", "enum-base[opt]", "`;`",
+]
+
+gram_tree["enum-key"] = [
+    ["`enum`"],
+    ["`enum`", "`class`"],
+    ["`enum`", "`struct`"],
+]
+
+gram_tree["enum-base"] = [
+    ["`:`", "type-specifier-seq"]
+]
+
+gram_tree["enumerator-list"] = [
+    ["enumerator-definition"],
+    ["enumerator-list", "`,`", "enumerator-definition"],
+]
+
+gram_tree["enumerator-definition"] = [
+    ["enumerator"],
+    ["enumerator", "`=`", "constant-expression"],
+]
+
+gram_tree["enumerator"] = [
+    "identifier", "attribute-specifier-seq[opt]",
+]
+
+gram_tree["using-enum-declaration"] = [
+    "`using`", "elaborated-enum-specifier", "`;`",
+]
+
+gram_tree["namespace-name"] = [
+    ["identifier"],
+    ["namespace-alias"],
+]
+
+gram_tree["namespace-definition"] = [
+    ["named-namespace-definition"],
+    ["unnamed-namespace-definition"],
+    ["nested-namespace-definition"],
+]
+
+gram_tree["named-namespace-definition"] = [
+    "`inline`[opt]", "`namespace`", "attribute-specifier-seq[opt]", "identifier", "`{`", "namespace-body", "`}`"
+]
+
+gram_tree["unnamed-namespace-definition"] = [
+    "`inline`[opt]", "`namespace`", "attribute-specifier-seq[opt]",  "`{`", "namespace-body", "`}`"
+]
+
+gram_tree["nested-namespace-definition"] = [
+    "`namespace`", "enclosing-namespace-specifier", "`::`", "`inline`[opt]", "identifier", "`{`", "namespace-body", "`}`",
+]
+
+gram_tree["enclosing-namespace-specifier"] = [
+    ["identifier"],
+    ["enclosing-namespace-specifier", "`::`", "`inline`[opt]", "identifier"],
+]
+
+gram_tree["namespace-body"] = [
+    "declaration-seq[opt]",
+]
+
+gram_tree["namespace-alias"] = [
+    "identifier"
+]
+
+gram_tree["namespace-alias-definition"] = [
+    "`namespace`", "identifier", "`=`", "qualified-namespace-specifier", "`;`",
+]
+
+gram_tree["qualified-namespace-specifier"] = [
+    "nested-name-specifier[opt]", "namespace-name",
+]
+
+gram_tree["using-directive"] = [
+    "attribute-specifier-seq[opt]", "`using`",  "`namespace`",  "nested-name-specifier[opt]", "namespace-name", "`;`"
+]
+
+gram_tree["using-declaration"] = [
+    "`using`", "using-declarator-list", "`;`",
+]
+
+gram_tree["using-declarator-list"] = [
+    ["using-declarator", "`...`[opt]"],
+    ["using-declarator-list", "`,`", "using-declarator", "`...`[opt]"],
+]
+
+gram_tree["using-declarator"] = [
+    "`typename`[opt]", "nested-name-specifier", "unqualified-id",
+]
+
+gram_tree["asm-declaration"] = [
+    "attribute-specifier-seq[opt]", "`asm`", "`(`", "string-literal", "`)`", "`;`",
+]
+
+gram_tree["linkage-specification"] = [
+    ["`extern`", "string-literal", "`{`", "declaration-seq[opt]", "`}`"],
+    ["`extern`", "string-literal", "declaration"],
+]
+
+gram_tree["attribute-specifier-seq"] = [
+    "attribute-specifier-seq[opt]", "attribute-specifier",
+]
+
+gram_tree["attribute-specifier"] = [
+    ["`[`", "`[`", "attribute-using-prefix[opt]", "attribute-list", "`]`", "`]`"],
+    ["alignment-specifier"],
+]
+
+gram_tree["alignment-specifier"] = [
+    ["`alignas`", "`(`", "type-id", "`...`[opt]", "`)`"],
+    ["`alignas`", "`(`", "constant-expression", "`...`[opt]", "`)`"],
+]
+
+gram_tree["attribute-using-prefix"] = [
+    "`using`", "attribute-namespace", "`:`",
+]
+
+gram_tree["attribute-list"] = [
+    ["attribute[opt]"],
+    ["attribute-list", "`,`", "attribute[opt]"],
+    ["attribute", "`...`"],
+    ["attribute-list", "`,`", "attribute", "`...`"],
+]
+
+gram_tree["attribute"] = [
+    "attribute-token", "attribute-argument-clause[opt]",
+]
+
+gram_tree["attribute-token"] = [
+    ["identifier"],
+    ["attribute-scoped-token"],
+]
+
+gram_tree["attribute-scoped-token"] = [
+    "attribute-namespace", "`::`", "identifier",
+]
+
+gram_tree["attribute-namespace"] = [
+    "identifier",
+]
+
+
+gram_tree["attribute-argument-clause"] = [
+    "`(`", "balanced-token-seq[opt]", "`)`",
+]
+
+gram_tree["balanced-token-seq"] = [
+    ["balanced-token"],
+    ["balanced-token-seq", "balanced-token"],
+]
+
+gram_tree["balanced-token"] = [
+    ["`(`", "balanced-token-seq[opt]", "`)`"],
+    ["`[`", "balanced-token-seq[opt]", "`]`"],
+    ["`{`", "balanced-token-seq[opt]", "`}`"],
+    ["identifier"],
+    ["keyword"],
+    ["literal"],
+    ["operator-or-punctuator"], #but not `(`, `)`,  `<`, `>`, `[`, `]`.
+]
+
+gram_tree["module-declaration"] = [
+    "`export`[opt]", "`module`", "module-name", "module-partition[opt]", "attribute-specifier-seq[opt]", "`;`",
+]
+
+gram_tree["module-name"] = [
+    "module-name-qualifier[opt]", "identifier",
+]
+
+gram_tree["module-partition"] = [
+   "`:`", "module-name-qualifier[opt]", "identifier",
+]
+
+gram_tree["module-name-qualifier"] = [
+    ["identifier", "`.`"],
+    ["module-name-qualifier", "identifier", "`.`"],
+]
+
+gram_tree["export-declaration"] = [
+    ["`export`", "declaration"],
+    ["`export`",  "`{`",  "declaration-seq[opt]", "`}`"],
+    ["`export`",  "module-import-declaration"],
+]
+
+gram_tree["module-import-declaration"] = [
+    ["`import`", "module-name", "attribute-specifier-seq[opt]"],
+    ["`import`", "module-partition", "attribute-specifier-seq[opt]"],
+    ["`import`", "header-name", "attribute-specifier-seq[opt]"],
+]
+
+gram_tree["global-module-fragment"] = [
+    "`module`", "`;`", "declaration-seq[opt]",
+]
+
+gram_tree["private-module-fragment"] = [
+    "`module`", "`:`", "`private`", "`;`", "declaration-seq[opt]",
+]
+
+gram_tree["class-name"] = [
+    ["identifier"],
+    ["simple-template-id"],
+]
+
+gram_tree["class-specifier"] = [
+    "class-head", "`{`", "member-specification[opt]", "`}`",
+]
+
+gram_tree["class-head"] = [
+    ["class-key", "attribute-specifier-seq[opt]", "class-head-name", "class-virt-specifier[opt]", "base-clause[opt]"],
+    ["class-key", "attribute-specifier-seq[opt]", "base-clause[opt]"],
+]
+
+gram_tree["class-head-name"] = [
+    "nested-name-specifier[opt]", "class-name",
+]
+
+gram_tree["class-virt-specifier"] = [
+    "`final`",
+]
+
+gram_tree["class-key"] = [
+    ["`class`"],
+    ["`struct`"],
+    ["`union`"],
+]
+
+gram_tree["member-specification"] = [
+    ["member-declaration", "member-specification[opt]"],
+    ["access-specifier", "`:`", "member-specification[opt]"],
+]
+
+gram_tree["member-declaration"] = [
+    ["attribute-specifier-seq[opt]", "decl-specifier-seq[opt]", "member-declarator-list[opt]", "`;`"],
+    ["function-definition"],
+    ["using-declaration"],
+    ["using-enum-declaration"],
+    ["static_assert-declaration"],
+    ["template-declaration"],
+    ["explicit-specialization"],
+    ["deduction-guide"],
+    ["alias-declaration"],
+    ["opaque-enum-declaration"],
+    ["empty-declaration"],
+]
+
+gram_tree["member-declarator-list"] = [
+    ["member-declarator"],
+    ["member-declarator-list", "`,`", "member-declarator"],
+]
+
+gram_tree["member-declarator"] = [
+    ["declarator", "virt-specifier-seq[opt]", "pure-specifier[opt]"],
+    ["declarator", "requires-clause"],
+    ["declarator", "brace-or-equal-initializer[opt]"],
+    ["identifier[opt]","attribute-specifier-seq[opt]", "`:`", "constant-expression", "brace-or-equal-initializer[opt]"],
+]
+
+gram_tree["virt-specifier-seq"] = [
+    ["virt-specifier"],
+    ["virt-specifier-seq", "virt-specifier"],
+]
+
+gram_tree["virt-specifier"] = [
+    ["`override`"],
+    ["`final`"],
+]
+
+gram_tree["pure-specifier"] = [
+    "`=`",  "`0`",
+]
+
+gram_tree["conversion-function-id"] = [
+    "`operator`", "conversion-type-id",
+]
+
+gram_tree["conversion-type-id"] = [
+    "type-specifier-seq", "conversion-declarator[opt]",
+]
+
+gram_tree["conversion-declarator"] = [
+    "ptr-operator", "conversion-declarator[opt]",
+]
+
+gram_tree["base-clause"] = [
+    "`:`", "base-specifier-list",
+]
+
+gram_tree["base-specifier-list"] = [
+    ["base-specifier", "`...`[opt]"],
+    ["base-specifier-list", "`,`", "base-specifier", "`...`[opt]"],
+]
+
+gram_tree["base-specifier"] = [
+    ["attribute-specifier-seq[opt]", "class-or-decltype"],
+    ["attribute-specifier-seq[opt]", "`virtual`", "access-specifier[opt]", "class-or-decltype"],
+    ["attribute-specifier-seq[opt]",  "access-specifier", "`virtual`[opt]", "class-or-decltype"],
+]
+
+gram_tree["class-or-decltype"] = [
+    ["nested-name-specifier[opt]", "type-name"],
+    ["nested-name-specifier", "`template`", "simple-template-id"],
+    ["decltype-specifier"],
+]
+
+gram_tree["access-specifier"] = [
+    ["`private`"],
+    ["`protected`"],
+    ["`public`"],
+]
+
+gram_tree["ctor-initializer"] = [
+    "`:`", "mem-initializer-list",
+]
+
+gram_tree["mem-initializer-list"] = [
+    ["mem-initializer", "`...`[opt]"],
+    ["mem-initializer-list", "mem-initializer", "`...`[opt]"],
+]
+
+gram_tree["mem-initializer"] = [
+    ["mem-initializer-id", "`(`", "expression-list[opt]"  ,"`)`"],
+    ["mem-initializer-id", "braced-init-list"],
+]
+
+gram_tree["mem-initializer-id"] = [
+    ["class-or-decltype"],
+    ["identifier"],
+]
+
+gram_tree["operator-function-id"] = [
+    "`operator`", "the_operator",
+]
+
+gram_tree["the_operator"] = [
+    ["`new`"], ["`delete`"], ["`new[]`"], ["`delete[]`", "`co_await`"],
+    ["`()`"],
+    ["`[]`"],
+    ["`->`"],["`->*`"],
+    ["`~`"],["`!`"],["`+`"],["`-`"],["`*`"],["`/`"],["`%`"],["`^`"],["`&`"],
+    ["`|`"],["`=`"],["`+=`"],["`-=`"],["`*=`"],["`/=`"],["`%=`"],["`^=`"],["`&=`"],
+    ["`|=`"],["`==`"],["`!=`"],["`<`"],["`>`"],["`<=`"],["`>=`"],["`<=>`"],["`&&`"],
+    ["`||`"],["`<<`"],["`>>`"],["`<<=`"],["`>>=`"],["`++`"],["`--`"],["`,`"],
+]
+
+gram_tree["literal-operator-id"] = [
+    ["`operator`", "string-literal", "identifier"],
+    ["`operator`", "user-defined-string-literal"],
+]
+
+gram_tree["template-declaration"] = [
+    ["template-head", "declaration"],
+    ["template-head", "concept-definition"],
+]
+
+gram_tree["template-head"] = [
+    "`template`", "`<`", "template-parameter-list", "`>`", "requires-clause",
+]
+
+gram_tree["template-parameter-list"] = [
+    ["template-parameter"],
+    ["template-parameter-list", "`,`", "template-parameter"],
+]
+
+gram_tree["requires-clause"] = [
+    "`requires`", "constraint-logical-or-expression",
+]
+
+gram_tree["constraint-logical-or-expression"] = [
+    ["constraint-logical-and-expression"],
+    ["constraint-logical-or-expression", "`||`", "constraint-logical-and-expression"],
+]
+
+gram_tree["constraint-logical-and-expression"] = [
+    ["primary-expression"],
+    ["constraint-logical-and-expression", "`&&`", "primary-expression"],
+]
+
+gram_tree["template-parameter"] = [
+    ["type-parameter"],
+    ["parameter-declaration"],
+]
+
+gram_tree["type-parameter"] = [
+    ["type-parameter-key", "`...`[opt]", "identifier[opt]"],
+    ["type-parameter-key", "identifier[opt]", "`=`", "type-id"],
+    ["type-constraint",  "`...`[opt]", "identifier[opt]"],
+    ["type-constraint", "identifier[opt]", "`=`", "type-id"],
+    ["template-head", "type-parameter-key", "`...`[opt]", "identifier[opt]"],
+    ["template-head", "type-parameter-key", "identifier[opt]", "`=`", "id-expression"],
+]
+
+gram_tree["type-parameter-key"] = [
+    ["`class`"],
+    ["`typename`"],
+]
+
+gram_tree["type-constraint"] = [
+    ["nested-name-specifier[opt]", "concept-name"],
+    ["nested-name-specifier[opt]", "concept-name", "`<`", "template-argument-list[opt]", "`>`"],
+]
+
+gram_tree["simple-template-id"] = [
+    "template-name", "`<`", "template-argument-list[opt]", "`>`"
+]
+
+gram_tree["template-id"] = [
+    ["simple-template-id"],
+    ["operator-function-id", "`<`", "template-argument-list[opt]", "`>`"],
+    ["literal-operator-id", "`<`", "template-argument-list[opt]", "`>`"],
+]
+
+gram_tree["template-name"] = [
+    "identifier",
+]
+
+gram_tree["template-argument-list"] = [
+    ["template-argument", "`...`[opt]"],
+    ["template-argument-list" , "`,`",  "template-argument", "`...`[opt]"],
+]
+
+gram_tree["template-argument"] = [
+    ["constant-expression"],
+    ["type-id"],
+    ["id-expression"],
+]
+
+gram_tree["constraint-expression"] = [
+    "logical-or-expression",
+]
+
+gram_tree["deduction-guide"] = [
+    "explicit-specifier[opt]", "template-name", "`(`", "parameter-declaration-clause", "`)`", "`->`", "simple-template-id", "`;`",
+]
+
+gram_tree["concept-definition"] = [
+    "`concept`", "concept-name", "`=`", "constraint-expression", "`;`",
+]
+
+gram_tree["concept-name"] = [
+    "identifier",
+]
+
+gram_tree["typename-specifier"] = [
+    ["`typename`", "nested-name-specifier", "identifier"],
+    ["`typename`", "nested-name-specifier", "`template`[opt]", "simple-template-id"],
+]
+
+gram_tree["explicit-instantiation"] = [
+    "`extern`[opt]", "`template`", "declaration",
+]
+
+gram_tree["explicit-specialization"] = [
+    "`template`", "`<`", "`>`", "declaration",
+]
+
+gram_tree["try-block"] = [
+    "`try`", "compound-statement", "handler-seq",
+]
+
+gram_tree["function-try-block"] = [
+    "`try`", "ctor-initializer[opt]", "compound-statement", "handler-seq",
+]
+
+gram_tree["handler-seq"] = [
+    "handler", "handler-seq[opt]",
+]
+
+gram_tree["handler"] = [
+    "`catch`", "`(`", "exception-declaration", "`)`", "compound-statement",
+]
+
+gram_tree["exception-declaration"] = [
+    ["attribute-specifier-seq[opt]", "type-specifier-seq", "declarator"],
+    ["attribute-specifier-seq[opt]", "type-specifier-seq", "abstract-declarator[opt]"],
+    ["`...`"],
+]
+
+gram_tree["noexcept-specifier"] = [
+    ["`noexcept`", "`(`", "constant-expression", "`)`"],
+    ["`noexcept`"],
+]
+
+gram_tree["preprocessing-file"] = [
+    ["group[opt]"],
+    ["module-file"],
+]
+
+gram_tree["module-file"] = [
+    "pp-global-module-fragment[opt]", "pp-module", "group[opt]", "pp-private-module-fragment[opt]",
+]
+
+gram_tree["pp-global-module-fragment"] = [
+    "`module`", "`;`", "new-line", "group[opt]",
+]
+
+gram_tree["pp-private-module-fragment"] = [
+    "`module`", "`:`", "`private`",  "`;`", "new-line", "group[opt]",
+]
+
+gram_tree["group"] = [
+    ["group-part"],
+    ["group", "group-part"],
+]
+
+gram_tree["group-part"] = [
+    ["control-line"],
+    ["if-section"],
+    ["text-line"],
+    ["`#`", "conditionally-supported-directive"],
+]
+
+gram_tree["control-line"] = [
+    ["`#`", "`include`", "pp-tokens", "new-line"],
+    ["pp-import"],
+    ["`#`", "`define`", "identifier", "replacement-list", "new-line"],
+    ["`#`", "`define`", "identifier", "lparen", "identifier-list[opt]", "`)`", "replacement-list", "new-line"],
+    ["`#`", "`define`", "identifier", "lparen", "`...`", "`)`", "replacement-list", "new-line"],
+    ["`#`", "`define`", "identifier", "lparen", "identifier-list", "`...`"  ,"`)`", "replacement-list", "new-line"],
+    ["`#`", "`undef`", "identifier", "new-line"],
+    ["`#`", "`line`", "pp-tokens", "new-line"],
+    ["`#`", "`error`", "pp-tokens[opt]", "new-line"],
+    ["`#`", "`pragma`", "pp-tokens[opt]", "new-line"],
+    ["`#`", "new-line"],
+]
+
+gram_tree["if-section"] = [
+    "if-group", "elif-groups[opt]", "else-group[opt]", "endif-line",
+]
+
+gram_tree["if-group"] = [
+    ["`#`", "`if`", "constant-expression", "new-line", "group[opt]"],
+    ["`#`", "`ifdef`", "identifier", "new-line", "group[opt]"],
+    ["`#`", "`ifndef`", "identifier", "new-line", "group[opt]"],
+]
+
+gram_tree["elif-groups"] = [
+    ["elif-group"],
+    ["elif-groups", "elif-group"],
+]
+
+gram_tree["elif-group"] = [
+    "`#`", "`elif`", "constant-expression", "new-line", "group[opt]",
+]
+
+gram_tree["else-group"] = [
+    "`#`", "`else`", "new-line", "group[opt]",
+]
+
+gram_tree["endif-line"] = [
+    "`#`", "`endif`", "new-line",
+]
+
+gram_tree["text-line"] = [
+    "pp-tokens[opt]", "new-line",
+]
+
+gram_tree["conditionally-supported-directive"] = [
+    "pp-tokens", "new-line",
+]
+
+gram_tree["lparen"] = [
+    # a ( character not immediately preceded by whitespace
+]
+
+gram_tree["identifier-list"] = [
+    ["identifier"],
+    ["identifier-list", "`,`", "identifier"],
+]
+
+gram_tree["replacement-list"] = [
+    "pp-tokens[opt]",
+]
+
+gram_tree["pp-tokens"] = [
+    ["preprocessing-token"],
+    ["pp-tokens", "preprocessing-token"],
+]
+
+gram_tree["new-line"] = [
+    # new line characters
+]
+
+gram_tree["defined-macro-expression"] = [
+    ["`defined`", "identifier"],
+    ["`defined`", "`(`", "identifier", "`)`"],
+]
+
+gram_tree["h-preprocessing-token"] = [
+    # any preprocessing-token other than >
+]
+
+gram_tree["h-pp-tokens"] = [
+    ["h-preprocessing-token"],
+    ["h-pp-tokens", "h-preprocessing-token"],
+]
+
+gram_tree["header-name-tokens"] = [
+    ["string-literal"],
+    ["`<`", "h-pp-tokens", "`>`"],
+]
+
+gram_tree["has-include-expression"] = [
+    ["`__has_include`", "`(`", "header-name", "`)`"],
+    ["`__has_include`", "`(`", "header-name-tokens", "`)`"],
+]
+
+gram_tree["has-attribute-expression"] = [
+    "`__has_cpp_attribute`", "`(`", "pp-tokens", "`)`",
+]
+
+gram_tree["pp-module"] = [
+    "`export`[opt]", "`module`", "pp-tokens[opt]", "`;`", "new-line",
+]
+
+gram_tree["pp-import"] = [
+    ["`export`[opt]", "`import`","header-name", "pp-tokens[opt]", "`;`", "new-line"],
+    ["`export`[opt]", "`import`","header-name-tokens", "pp-tokens[opt]", "`;`", "new-line"],
+    ["`export`[opt]", "`import`","pp-tokens", "`;`", "new-line"],
+]
+
+gram_tree["va-opt-replacement"] = [
+    "`__VA_OPT__`", "`(`", "pp-tokens[opt]", "`)`",
+]
+
+gram_tree["hex-quad"] = [
+    "hexadecimal-digit", "hexadecimal-digit", "hexadecimal-digit", "hexadecimal-digit",
+]
+
+gram_tree["universal-character-name"] = [
+    ["`\\u`", "hex-quad"],
+    ["`\\U`", "hex-quad", "hex-quad"],
+]
+
+gram_tree["preprocessing-token"] = [
+    ["header-name"],
+    ["`import`"],
+    ["`module`"],
+    ["`export`"],
+    ["identifier"],
+    ["pp-number"],
+    ["character-literal"],
+    ["user-defined-character-literal"],
+    ["string-literal"],
+    ["user-defined-string-literal"],
+    ["preprocessing-op-or-punc"],
+    # each non-whitespace character that cannot be one of the above
+]
+
+gram_tree["token"] = [
+    ["identifier"],
+    ["keyword"],
+    ["literal"],
+    ["operator-or-punctuator"],
+]
+
+gram_tree["header-name"] = [
+    ["`<`", "h-char-sequence", "`>`"],
+    ['`"`', "q-char-sequence", '`"`'],
+]
+
+gram_tree["h-char-sequence"] = [
+    ["h-char"],
+    ["h-char-sequence", "h-char"],
+]
+
+gram_tree["h-char"] = [
+    # any member of the source character set except new-line and >
+]
+
+gram_tree["q-char-sequence"] = [
+    ["q-char"],
+    ["q-char-sequence", "q-char"],
+]
+
+gram_tree["q-char"] = [
+    # any member of the source character set except new-line and "
+]
+
+gram_tree["pp-number"] = [
+    ["digit"],
+    ["`.`", "digit"],
+    ["pp-number", "digit"],
+    ["pp-number", "identifier-nondigit"],
+    ["pp-number", "`'`", "digit"],
+    ["pp-number", "`'`", "nondigit"],
+    ["pp-number", "`e`", "sign"],
+    ["pp-number", "`E`", "sign"],
+    ["pp-number", "`p`", "sign"],
+    ["pp-number", "`P`", "sign"],
+    ["pp-number", "`.`"],
+]
+
+gram_tree["identifier"] = [
+    ["identifier-nondigit"],
+    ["identifier", "identifier-nondigit"],
+    ["identifier", "digit"],
+]
+
+gram_tree["identifier-nondigit"] = [
+    ["nondigit"],
+    ["universal-character-name"],
+]
+
+gram_tree["nondigit"] = [
+    # left lexer to parse it.
+]
+
+gram_tree["digit"] = [
+    # left lexer to parse it.
+]
+
+gram_tree["keyword"] = [
+    # left lexer to parse it.
+]
+
+gram_tree["preprocessing-op-or-punc"] = [
+    ["preprocessing-operator"],
+    ["operator-or-punctuator"],
+]
+
+gram_tree["preprocessing-operator"] = [
+    ["`#`"], ["`##`"], ["`%:`"], ["`%:%:`"],
+]
+
+gram_tree["operator-or-punctuator"] = [
+    ["`{`"], ["`}`"], ["`[`"], ["`]`"], ["`(`"], ["`)`"],
+    ["`<:`"], ["`:>`"], ["`<%`"], ["`%>`"], ["`;`"], ["`:`"], ["`...`"],
+    ["`?`"], ["`::`"], ["`.`"], ["`.*`"], ["`->`"], ["`->*`"], ["`~`"],
+    ["`!`"], ["`+`"], ["`-`"], ["`*`"], ["`/`"], ["`%`"], ["`^`"], ["`&`"], ["`|`"],
+    ["`=`"], ["`+=`"], ["`-=`"], ["`*=`"], ["`/=`"], ["`%=`"], ["`^=`"], ["`&=`"], ["`|=`"],
+    ["`==`"], ["`!=`"], ["`<`"], ["`>`"], ["`<=`"], ["`>=`"], ["`<=>`"], ["`&&`"], ["`||`"],
+    ["`<<`"], ["`>>`"], ["`<<=`"], ["`>>=`"], ["`++`"], ["`--`"], ["`,`"],
+    ["`and`"], ["`or`"], ["`xor`"], ["`not`"], ["`bitand`"], ["`bitor`"], ["`compl`"],
+    ["`and_eq`"], ["`or_eq`"], ["`xor_eq`"], ["`not_eq`"],
+]
+
+gram_tree["literal"] = [
+    ["integer-literal"],
+    ["character-literal"],
+    ["floating-point-literal"],
+    ["string-literal"],
+    ["boolean-literal"],
+    ["pointer-literal"],
+    ["user-defined-literal"],
+]
+
+gram_tree["integer-literal"] = [
+    ["binary-literal", "integer-suffix[opt]"],
+    ["octal-literal", "integer-suffix[opt]"],
+    ["decimal-literal", "integer-suffix[opt]"],
+    ["hexadecimal-literal", "integer-suffix[opt]"],
+]
+
+gram_tree["binary-literal"] = [
+    ["`0b`", "binary-digit"],
+    ["`0B`", "`binary-digit`"],
+    ["binary-literal", "`'`"],
+    ["binary-literal", "`'`[opt]", "binary-digit"],
+]
+
+gram_tree["octal-literal"] = [
+    ["`0`"],
+    ["octal-literal", "`'`[opt]", "octal-digit"],
+]
+
+gram_tree["decimal-literal"] = [
+    ["nonzero-digit"],
+    ["decimal-literal", "`'`[opt]", "digit"],
+]
+
+gram_tree["hexadecimal-literal"] = [
+    "hexadecimal-prefix", "hexadecimal-digit-sequence",
+]
+
+gram_tree["binary-digit"] = [
+    ["`0`"],
+    ["`1`"],
+]
+
+gram_tree["octal-digit"] = [
+    ["`0`"],
+    ["`1`"],
+    ["`2`"],
+    ["`3`"],
+    ["`4`"],
+    ["`5`"],
+    ["`6`"],
+    ["`7`"],
+]
+
+gram_tree["nonzero-digit"] = [
+    ["`1`"],
+    ["`2`"],
+    ["`3`"],
+    ["`4`"],
+    ["`5`"],
+    ["`6`"],
+    ["`7`"],
+    ["`8`"],
+    ["`9`"],
+]
+
+gram_tree["hexadecimal-prefix"] = [
+    ["`0x`"], ["`0X`"],
+]
+
+gram_tree["hexadecimal-digit-sequence"] = [
+    ["hexadecimal-digit"],
+    ["hexadecimal-digit-sequence", "`'`[opt]", "hexadecimal-digit"],
+]
+
+gram_tree["hexadecimal-digit"] = [
+    ["`0`"],
+    ["`1`"],
+    ["`2`"],
+    ["`3`"],
+    ["`4`"],
+    ["`5`"],
+    ["`6`"],
+    ["`7`"],
+    ["`8`"],
+    ["`9`"],
+    ["`A`"],
+    ["`B`"],
+    ["`C`"],
+    ["`D`"],
+    ["`E`"],
+    ["`F`"],
+]
+
+gram_tree["integer-suffix"] = [
+    ["unsigned-suffix", "long-suffix[opt]"],
+    ["unsigned-suffix", "long-long-suffix[opt]"],
+    ["long-suffix", "unsigned-suffix[opt]"],
+    ["long-long-suffix", "unsigned-suffix[opt]"],
+]
+
+gram_tree["unsigned-suffix"] = [
+    ["`u`"], ["`U`"],
+]
+
+gram_tree["long-suffix"] = [
+    ["`l`"], ["`L`"],
+]
+
+gram_tree["long-long-suffix"] = [
+    ["`ll`"], ["`LL`"],
+]
+
+gram_tree["character-literal"] = [
+    "encoding-prefix[opt]", "`'`","c-char-sequence", "`'`",
+]
+
+gram_tree["encoding-prefix"] = [
+    ["`u8`"],["`u`"], ["`U`"], ["`L`"],
+]
+
+gram_tree["c-char-sequence"] = [
+    ["c-char"],
+    ["c-char-sequence", "c-char"],
+]
+
+gram_tree["c-char"] = [
+    # any member of the basic source character set except the `'`, `\``, or "new-line" character
+    ["escape-sequence"],
+    ["universal-character-name"],
+]
+
+gram_tree["escape-sequence"] = [
+    ["simple-escape-sequence"],
+    ["octal-escape-sequence"],
+    ["hexadecimal-escape-sequence"],
+]
+
+gram_tree["simple-escape-sequence"] = [
+    ["`\\'`"], ['`\\"`'], ["`\\?`"], ["`\\\\"],
+    ["`\\a`"], ["`\\b`"], ["`\\f`"], ["`\\n`"], ["`\\r`"], ["`\\t`"], ["`\\v"],
+]
+
+gram_tree["octal-escape-sequence"] = [
+    ['`\\`', "octal-digit"],
+    ['`\\`', "octal-digit", "octal-digit"],
+    ['`\\`', "octal-digit", "octal-digit", "octal-digit"],
+]
+
+gram_tree["hexadecimal-escape-sequence"] = [
+    ["`\\x`", "hexadecimal-digit"],
+    ["hexadecimal-escape-sequence", "hexadecimal-digit"],
+]
+
+gram_tree["floating-point-literal"] = [
+    ["decimal-floating-point-literal"],
+    ["hexadecimal-floating-point-literal"],
+]
+
+gram_tree["decimal-floating-point-literal"] = [
+    ["fractional-constant", "exponent-part[opt]", "floating-point-suffix[opt]"],
+    ["digit-sequence", "exponent-part[opt]", "floating-point-suffix[opt]"],
+]
+
+gram_tree["hexadecimal-floating-point-literal"] = [
+    ["hexadecimal-prefix", "hexadecimal-fractional-constant", "binary-exponent-part", "floating-point-suffix[opt]"],
+    ["hexadecimal-prefix", "hexadecimal-digit-sequence", "binary-exponent-part", "floating-point-suffix[opt]"],
+]
+
+gram_tree["fractional-constant"] = [
+    ["digit-sequence[opt]", "`.`", "digit-sequence"],
+    ["digit-sequence", "`.`"],
+]
+
+gram_tree["hexadecimal-fractional-constant"] = [
+    ["hexadecimal-digit-sequence[opt]", "`.`", "hexadecimal-digit-sequence"],
+    ["hexadecimal-digit-sequence", "`.`"],
+]
+
+gram_tree["exponent-part"] = [
+    ["`e`", "sign[opt]", "digit-sequence"],
+    ["`E`", "sign[opt]", "digit-sequence"],
+]
+
+gram_tree["binary-exponent-part"] = [
+    ["`p`", "sign[opt]", "digit-sequence"],
+    ["`P`", "sign[opt]", "digit-sequence"],
+]
+
+gram_tree["sign"] = [
+    ["`+`"], ["`-`"],
+]
+
+gram_tree["digit-sequence"] = [
+    ["digit"],
+    ["digit-sequence", "`'`[opt]", "digit"],
+]
+
+gram_tree["floating-point-suffix"] = [
+    ["`f`"], ["`l`"], ["`F`"], ["`L`"],
+]
+
+gram_tree["string-literal"] = [
+    ["encoding-prefix[opt]", '`"`', "s-char-sequence[opt]", '`"`'],
+    ["encoding-prefix[opt]", '`R`', "raw-string"],
+]
+
+gram_tree["s-char-sequence"] = [
+    ["s-char"],
+    ["s-char-sequence", "s-char"],
+]
+
+gram_tree["s-char"] = [
+    # any member of the basic source character set except the `"`, `\``, or "new-line" character
+    ["escape-sequence"],
+    ["universal-character-name"],
+]
+
+gram_tree["raw-string"] = [
+    '`"`', "d-char-sequence[opt]", "`(`", "r-char-sequence[opt]"  ,"`)`", "d-char-sequence[opt]", '`"`',
+]
+
+gram_tree["r-char-sequence"] = [
+    ["r-char"],
+    ["r-char-sequence", "r-char"],
+]
+
+gram_tree["r-char"] = [
+    # any member of the source character set, except a `)` followed by
+    # the initial "d-char-sequence" (which may be empty) followed by a `"`.
+]
+
+gram_tree["d-char-sequence"] = [
+    ["d-char"],
+    ["d-char-sequence", "d-char"],
+]
+
+gram_tree["d-char"] = [
+    # any member of the basic source character set except:
+    # space, the `(`, `)`, `\`, and the control characters
+    # representing horizontal tab, vertical tab, form feed, and newline.
+]
+
+gram_tree["boolean-literal"] = [
+    ["`false`"],
+    ["`true`"],
+]
+
+gram_tree["pointer-literal"] = [
+    "`nullptr`",
+]
+
+gram_tree["user-defined-literal"] = [
+    ["user-defined-integer-literal"],
+    ["user-defined-floating-point-literal"],
+    ["user-defined-string-literal"],
+    ["user-defined-character-literal"],
+]
+
+gram_tree["user-defined-integer-literal"] = [
+    ["decimal-literal", "ud-suffix"],
+    ["octal-literal", "ud-suffix"],
+    ["hexadecimal-literal", "ud-suffix"],
+    ["binary-literal", "ud-suffix"],
+]
+
+gram_tree["user-defined-floating-point-literal"] = [
+    ["fractional-constant", "exponent-part[opt]", "ud-suffix"],
+    ["digit-sequence", "exponent-part", "ud-suffix"],
+    ["hexadecimal-prefix", "hexadecimal-fractional-constant", "binary-exponent-part", "ud-suffix"],
+    ["hexadecimal-prefix", "hexadecimal-digit-sequence", "binary-exponent-part", "ud-suffix"],
+]
+
+gram_tree["user-defined-string-literal"] = [
+    "string-literal", "ud-suffix",
+]
+
+gram_tree["user-defined-character-literal"] = [
+    "character-literal", "ud-suffix",
+]
+
+gram_tree["ud-suffix"] = [
+    "identifier",
+]

--- a/gram/create_parse_functions.py
+++ b/gram/create_parse_functions.py
@@ -1,0 +1,69 @@
+#
+# MIT License
+# Copyright (c) 2023 mxlol233 (mxlol233@outlook.com)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+from config import gram_tree
+
+
+def create_serial_parse_function():
+    pass
+
+
+def create_serial_parallel_function():
+    pass
+
+def remove_opt(s:str):
+    if s.endswith("[opt]"):
+        s = s.replace("[opt]", "")
+    return s
+
+if __name__ =="__main__":
+    sp_tokens = {}
+    for k,v in gram_tree.items():
+        if len(v) == 0:
+            print(k)
+        else:
+            # If first element is `str`, then this grammar definition
+            # has only one `SerialParseFunction`.
+            if isinstance(v[0], str):
+                for s_ in v:
+                    assert isinstance(s_, str)
+                    s = remove_opt(s_)
+                    if s.startswith('`'):
+                        sp_tokens[s] = 1
+                    else:
+                        assert s in gram_tree
+            # Otherwise, it has several `ParallelParseFunction`.
+            else:
+                for s_v in v:
+                    assert isinstance(s_v, list)
+                    for s_ in s_v:
+                        assert isinstance(s_, str)
+                        s = remove_opt(s_)
+                        if s.startswith('`'):
+                            sp_tokens[s] = 1
+                        else:
+                            assert s in gram_tree
+
+                pass
+    for k in sp_tokens.keys():
+        print(f"\"{k}\":{None},")

--- a/include/diag/kinds.def
+++ b/include/diag/kinds.def
@@ -29,7 +29,11 @@ DIAG(global_module_expect_semi,
      "start of the translation unit.",
      "expected `;` after `module`.", Level::kError)
 DIAG(back_slash_new_space, "back_slash_new_space", "", Level::kError)
-DIAG(module_decl_expect_kw_module, "expected `module` after `export`.", "", Level::kError)
-DIAG(module_decl_expect_ident, "expected `identifier` after `module`.", "", Level::kError)
+DIAG(module_decl_expect_kw_module, "expected `module` after `export`.", "",
+     Level::kError)
+DIAG(module_decl_expect_ident, "expected `identifier` after `module`.", "",
+     Level::kError)
+DIAG(simple_declaration_expect_semi, "expected `;` in simple_declaration.", "",
+     Level::kError)
 
 #undef DIAG

--- a/include/parser.h
+++ b/include/parser.h
@@ -25,6 +25,7 @@
 
 #include "lexer.h"
 #include "src.h"
+#include "token.h"
 
 namespace lps::parser {
 
@@ -40,12 +41,14 @@ struct ParseFunctionOutputs {
 #define SET_MOVE(A, B)                            \
   (A)->work_ = (B).work_;                         \
   (A)->file_id_ = (B).file_id_;                   \
+  (A)->last_token_ = (B).last_token_;             \
   (A)->diag_inputs_(std::move((B).diag_inputs_)); \
   (A)->start_ = (B).start_;
 
 #define SET(A, B)                       \
   (A)->work_ = (B).work_;               \
   (A)->file_id_ = (B).file_id_;         \
+  (A)->last_token_ = (B).last_token_;   \
   (A)->diag_inputs_ = (B).diag_inputs_; \
   (A)->start_ = (B).start_;
 
@@ -57,6 +60,12 @@ struct ParseFunctionOutputs {
 
   template <meta::Str TagNameOther>
   explicit ParseFunctionOutputs(ParseFunctionOutputs<TagNameOther>&& other) {
+    SET_MOVE(this, other);
+  }
+
+  template <meta::Str TagNameOther>
+  explicit ParseFunctionOutputs(
+      const ParseFunctionOutputs<TagNameOther>&& other) {
     SET_MOVE(this, other);
   }
 
@@ -73,30 +82,48 @@ struct ParseFunctionOutputs {
     diag_inputs_.append(std::move(a));
   }
   template <meta::Str TagNameOther>
-  void concat_diag_inputs_and_remove(
-      ParseFunctionOutputs<TagNameOther>& other) {
-    for (const auto& a : other.diag_inputs_) {
-      typename decltype(diag_inputs_)::ele_type b(a);
-      this->diag_inputs_.append(b);
+  void concat(ParseFunctionOutputs<TagNameOther>&& other, bool opt = true) {
+    if (!opt) {
+      for (const auto& a : other.diag_inputs_) {
+        typename decltype(diag_inputs_)::ele_type b(a);
+        this->diag_inputs_.append(b);
+      }
+      this->work_ = this->work_ && other.work_;
     }
-    other.diag_inputs_.release();
+
+    this->file_id_ = other.file_id_;
+    this->start_ = other.start_;
+    this->last_token_ = other.last_token_;
   }
 
   bool work_{false};
   const char* start_{nullptr};
   uint32_t file_id_{0};
+  token::Token<TagName> last_token_;
   basic::Vector<4, diag::DiagInputs<TagName>, TagName + "_DiagInputs">
       diag_inputs_;
 };
 
 template <meta::Str TagName>
-struct ParseFunctionInputs {
+struct ParseFunctionInputs : virtual public basic::mem::TraceTag<TagName> {
 
   explicit ParseFunctionInputs() = default;
+  explicit ParseFunctionInputs(
+      bool opt, const char* start = nullptr, uint32_t file_id = 0,
+      const token::Token<TagName>& tok = token::Token<TagName>())
+      : opt_(opt), file_id_(file_id), start_(start), last_token_(tok) {}
 
-#define SET(A, B)               \
-  (A)->opt_ = (B).opt_;         \
-  (A)->file_id_ = (B).file_id_; \
+  explicit ParseFunctionInputs(bool opt, const char* start, uint32_t file_id,
+                               token::Token<TagName>&& tok)
+      : opt_(opt),
+        file_id_(file_id),
+        start_(start),
+        last_token_(std::move(tok)) {}
+
+#define SET(A, B)                     \
+  (A)->opt_ = (B).opt_;               \
+  (A)->file_id_ = (B).file_id_;       \
+  (A)->last_token_ = (B).last_token_; \
   (A)->start_ = (B).start_;
 
   template <meta::Str OtherTagName>
@@ -121,11 +148,25 @@ struct ParseFunctionInputs {
   bool opt_{false};
   const char* start_{nullptr};
   uint32_t file_id_{0};
+
+  token::Token<TagName> last_token_;
 };
 
 template <meta::Str TagName>
 class ParseFunction {
  public:
+  using type = ParseFunction<TagName>;
+  using output_type = ParseFunctionOutputs<TagName>;
+  using custom_func_type = std::function<output_type(type*)>;
+
+  template <typename... Params>
+  explicit ParseFunction(Params... params) : params_(params...) {}
+  template <typename... Params>
+  explicit ParseFunction(custom_func_type func, Params... params)
+      : custom_func_(func), params_(params...) {}
+  explicit ParseFunction(const ParseFunctionInputs<TagName>& param,
+                         custom_func_type func)
+      : params_(param), custom_func_(func) {}
   explicit ParseFunction(const ParseFunctionInputs<TagName>& param)
       : params_(param) {}
   explicit ParseFunction(ParseFunctionInputs<TagName>&& param)
@@ -138,14 +179,85 @@ class ParseFunction {
   explicit ParseFunction(ParseFunctionInputs<TagNameOther>&& param)
       : params_(std::move(param)) {}
 
-  ParseFunctionOutputs<TagName> operator()() {}
+  virtual output_type operator()() {
+    if (custom_func_) {
+      return custom_func_(this);
+    }
+    ParseFunctionOutputs<TagName> output;
+    output.file_id_ = this->file_id();
+    output.start_ = this->start();
+    output.last_token_ = this->last_token();
+    return output;
+  };
 
   [[nodiscard]] bool opt() const { return params_.opt_; }
   [[nodiscard]] const char* start() const { return params_.start_; }
   [[nodiscard]] uint32_t file_id() const { return params_.file_id_; }
+  [[nodiscard]] token::Token<TagName> last_token() const {
+    return params_.last_token_;
+  }
+
+  [[nodiscard]] inline size_t len() const {
+    return src::Manager::instance().size(params_.file_id_);
+  }
+
+  [[nodiscard]] inline const char* eof() const {
+    auto content = src::Manager::instance().ref<TagName + "_file_contents">(
+        params_.file_id_);
+    return content.data() + len();
+  }
+  [[nodiscard]] inline bool valid() const { return params_.start_ < eof(); }
+
+  void opt(bool opt) { params_.opt_ = opt; }
+  void start(const char* start) { params_.start_ = start; }
+  void file_id(uint32_t file_id) { params_.file_id_ = file_id; }
+  void last_token(const token::Token<TagName>& tok) {
+    params_.last_token_ = tok;
+  }
+  template <meta::Str TagNameOther>
+  void last_token(const token::Token<TagNameOther>& tok) {
+    params_.last_token_ = tok;
+  }
+
+  static type create_single_token_check(token::tok::TokenKind token_kind,
+                                        diag::DiagKind diag_kind) {
+    type::custom_func_type z([&token_kind, &diag_kind](type* func) {
+      ParseFunctionOutputs<TagName> output;
+      output.file_id_ = func->file_id();
+      output.start_ = func->start();
+      output.last_token_ = func->last_token();
+
+      if (!func->valid()) {
+        return output;
+      }
+      token::Token<TagName + "_first_token"> tok;
+      lexer::Lexer lexer(func->file_id(), func->start());
+      lexer.lex(tok);
+
+      if (tok.kind() != token_kind) {
+        if (!func->opt()) {
+          output.diag_record(
+              diag::record<TagName>(tok, diag_kind, output.last_token_));
+        }
+        output.work_ = false;
+        return output;
+      }
+
+      {
+        output.last_token_ = tok;
+        output.start_ = lexer.cur();
+        output.file_id_ = tok.file_id();
+        output.work_ = true;
+      }
+
+      return output;
+    });
+    return type(z, false);
+  }
 
  protected:
   ParseFunctionInputs<TagName> params_;
+  custom_func_type custom_func_{nullptr};
 };
 
 }  // namespace details
@@ -155,28 +267,6 @@ class Parser {
  public:
   explicit Parser() = default;
   void parse(uint32_t file_id);
-
- private:
-  void translation_unit(uint32_t file_id);
-  void declaration_seq();
-
-  // declaration
-  void block_declaration() {}
-  void nodeclspec_function_declaration() {}
-  void function_definition() {}
-  void template_declaration() {}
-  void deduction_guide() {}
-  void explicit_instantiation() {}
-  void explicit_specialization() {}
-  void export_declaration() {}
-  void linkage_specification() {}
-  void namespace_definition() {}
-  void empty_declaration() {}
-  void attribute_declaration() {}
-  void module_import_declaration() {}
-
-  void module_partition() {}
-  void attribute_specifier_seq() {}
 };
 
 }  // namespace lps::parser

--- a/include/parser/decl.h
+++ b/include/parser/decl.h
@@ -1,0 +1,370 @@
+/*
+* MIT License
+* Copyright (c) 2023 mxlol233 (mxlol233@outlook.com)
+
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+*LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#pragma once
+
+#include "diag.h"
+#include "parser/function.h"
+#include "token.h"
+
+namespace lps::parser::details {
+
+// declaration_seq:
+//  declaration
+//  declaration_seq declaration
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> DeclarationSeq<TagName>::operator()() {
+  auto output = base::operator()();
+  if (!this->valid()) {
+    return output;
+  }
+  auto cur_token = output.last_token_;
+
+  token::Token<TagName + "_first_token"> tok;
+
+  lexer::Lexer lexer(this->file_id(), this->start());
+  lexer.lex(tok);
+
+  SerialParseFunctions serial_funcs(ParseFunctionInputs<TagName>(false),
+                                    DeclarationSeq<>(false),
+                                    Declaration<>(false));
+
+  ParallelParseFunctions parallel_funcs(
+      ParseFunctionInputs<TagName>(false, lexer.cur(), this->file_id(),
+                                   token::Token<TagName>(tok)),
+      Declaration<>(false), std::move(serial_funcs));
+
+  return parallel_funcs();
+}
+
+// declaration:
+//   block_declaration
+//   nodeclspec_function_declaration
+//   function_definition
+//   template_declaration
+//   deduction_guide
+//   explicit_instantiation
+//   explicit_specialization
+//   export_declaration
+//   linkage_specification
+//   namespace_definition
+//   empty_declaration
+//   attribute_declaration
+//   module_import_declaration
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> Declaration<TagName>::operator()() {
+  auto output = base::operator()();
+  if (!this->valid()) {
+    return output;
+  }
+
+  token::Token<TagName + "_first_token"> tok;
+
+  lexer::Lexer lexer(this->file_id(), this->start());
+  lexer.lex(tok);
+
+  ParallelParseFunctions parallel_funcs(
+      ParseFunctionInputs<TagName>(false, lexer.cur(), this->file_id(),
+                                   token::Token<TagName>(tok)),
+      BlockDeclaration<>(false), NodeclspecFunctionDeclaration<>(false),
+      FunctionDefinition<>(false), TemplateDeclaration<>(false),
+      DeductionGuide<>(false), ExplicitInstantiation<>(false),
+      ExplicitSpecialization<>(false), ExportDeclaration<>(false),
+      LinkageSpecification<>(false), NamespaceDefinition<>(false),
+      EmptyDeclaration<>(false), AttributeDeclaration<>(false),
+      ModuleImportDeclaration<>(false));
+
+  return parallel_funcs();
+}
+
+// block_declaration:
+// simple-declaration
+// asm-declaration
+// namespace-alias-definition
+// using-declaration
+// using-enum-declaration
+// using-directive
+// static_assert-declaration
+// alias-declaration
+// opaque-enum-declaration
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> BlockDeclaration<TagName>::operator()() {
+  auto output = base::operator()();
+  if (!this->valid()) {
+    return output;
+  }
+
+  token::Token<TagName + "_first_token"> tok;
+
+  lexer::Lexer lexer(this->file_id(), this->start());
+  lexer.lex(tok);
+
+  ParallelParseFunctions parallel_funcs(
+      ParseFunctionInputs<TagName>(false, lexer.cur(), this->file_id(),
+                                   token::Token<TagName>(tok)),
+      SimpleDeclaration<>(false), AsmDeclaration<>(false),
+      NamespaceAliasDefinition<>(false), UsingDeclaration<>(false),
+      UsingEnumDeclaration<>(false), UsingDirective<>(false),
+      StaticAssertDeclaration<>(false), AliasDeclaration<>(false),
+      OpaqueEnumDeclaration<>(false));
+
+  return parallel_funcs();
+}
+
+// simple_declaration:
+//  decl_specifier_seq init_declarator_list[opt] `;`
+//  attribute_specifier_seq decl_specifier_seq init_declarator_list `;`
+//  attribute_specifier_seq[opt] decl-specifier-seq ref-qualifier[opt] `[` identifier_list `]` initializer `;`
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> SimpleDeclaration<TagName>::operator()() {
+  auto output = base::operator()();
+  if (!this->valid()) {
+    return output;
+  }
+
+  token::Token<TagName + "_first_token"> tok;
+
+  lexer::Lexer lexer(this->file_id(), this->start());
+  lexer.lex(tok);
+
+  SerialParseFunctions serial_funcs0(
+      ParseFunctionInputs<TagName + "_serial_funcs0">(
+          false, lexer.cur(), this->file_id(),
+          token::Token<TagName + "_serial_funcs0">(tok)),
+      DeclSpecifierSeq<>(false), InitDeclaratorList<>(true),
+      ParseFunction<TagName + "_serial_funcs0" + "_check `;`">::
+          create_single_token_check(
+              token::tok::TokenKind::semi,
+              diag::DiagKind::simple_declaration_expect_semi));
+
+  SerialParseFunctions serial_funcs1(
+      ParseFunctionInputs<TagName + "_serial_funcs1">(
+          false, lexer.cur(), this->file_id(),
+          token::Token<TagName + "_serial_funcs1">(tok)),
+      AttributeSpecifierSeq<>(false), DeclSpecifierSeq<>(false),
+      InitDeclaratorList<>(false),
+      ParseFunction<TagName + "_serial_funcs1" + "_check `;`">::
+          create_single_token_check(
+              token::tok::TokenKind::semi,
+              diag::DiagKind::simple_declaration_expect_semi));
+
+  SerialParseFunctions serial_funcs2(
+      ParseFunctionInputs<TagName + "_serial_funcs2">(
+          false, lexer.cur(), this->file_id(),
+          token::Token<TagName + "_serial_funcs2">(tok)),
+      AttributeSpecifierSeq<>(true), DeclSpecifierSeq<>(false),
+      RefQualifier<>(true),
+      ParseFunction<TagName + "_serial_funcs2" + "_check `[`">::
+          create_single_token_check(
+              token::tok::TokenKind::l_square,
+              diag::DiagKind::simple_declaration_expect_semi),
+      IdentifierList<>(false),
+      ParseFunction<TagName + "_serial_funcs2" + "_check `]`">::
+          create_single_token_check(
+              token::tok::TokenKind::r_square,
+              diag::DiagKind::simple_declaration_expect_semi),
+      Initializer<>(false),
+      ParseFunction<TagName + "_serial_funcs2" + "_check `;`">::
+          create_single_token_check(
+              token::tok::TokenKind::semi,
+              diag::DiagKind::simple_declaration_expect_semi));
+
+  ParallelParseFunctions parallel_funcs(
+      ParseFunctionInputs<TagName>(true, lexer.cur(), this->file_id(),
+                                   token::Token<TagName>(tok)),
+      std::move(serial_funcs0), std::move(serial_funcs1),
+      std::move(serial_funcs2));
+
+  return parallel_funcs();
+}
+
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> RefQualifier<TagName>::operator()() {
+  return base::operator()();
+}
+
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> IdentifierList<TagName>::operator()() {
+  return base::operator()();
+}
+
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> InitDeclaratorList<TagName>::operator()() {
+  return base::operator()();
+}
+
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> Initializer<TagName>::operator()() {
+  return base::operator()();
+}
+
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> DeclSpecifierSeq<TagName>::operator()() {
+  return base::operator()();
+}
+
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> AsmDeclaration<TagName>::operator()() {
+  return base::operator()();
+}
+
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> NamespaceAliasDefinition<TagName>::operator()() {
+  return base::operator()();
+}
+
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> UsingEnumDeclaration<TagName>::operator()() {
+  return base::operator()();
+}
+
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> UsingDirective<TagName>::operator()() {
+  return base::operator()();
+}
+
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> StaticAssertDeclaration<TagName>::operator()() {
+  return base::operator()();
+}
+
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> AliasDeclaration<TagName>::operator()() {
+  return base::operator()();
+}
+
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> OpaqueEnumDeclaration<TagName>::operator()() {
+  return base::operator()();
+}
+
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> UsingDeclaration<TagName>::operator()() {
+  return base::operator()();
+}
+
+// nodeclspec_function_declaration:
+//  attribute_specifier_seq[opt] declarator `;`
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName>
+NodeclspecFunctionDeclaration<TagName>::operator()() {
+  auto output = base::operator()();
+  if (!this->valid()) {
+    return output;
+  }
+  token::Token<TagName + "_first_token"> tok;
+
+  lexer::Lexer lexer(this->file_id(), this->start());
+  lexer.lex(tok);
+
+  SerialParseFunctions serial_funcs(
+      ParseFunctionInputs<TagName>(false),
+      AttributeSpecifierSeq<TagName + "_AttributeSpecifierSeq">(true),
+      Declarator<TagName + "_Declarator">(false));
+  return serial_funcs();
+}
+
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> FunctionDefinition<TagName>::operator()() {
+  return base::operator()();
+}
+
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> TemplateDeclaration<TagName>::operator()() {
+  return base::operator()();
+}
+
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> DeductionGuide<TagName>::operator()() {
+  return base::operator()();
+}
+
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> ExplicitInstantiation<TagName>::operator()() {
+  return base::operator()();
+}
+
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> ExplicitSpecialization<TagName>::operator()() {
+  return base::operator()();
+}
+
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> ExportDeclaration<TagName>::operator()() {
+  return base::operator()();
+}
+
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> LinkageSpecification<TagName>::operator()() {
+  return base::operator()();
+}
+
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> NamespaceDefinition<TagName>::operator()() {
+  return base::operator()();
+}
+
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> EmptyDeclaration<TagName>::operator()() {
+  return base::operator()();
+}
+
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> AttributeDeclaration<TagName>::operator()() {
+  return base::operator()();
+}
+
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> ModuleImportDeclaration<TagName>::operator()() {
+  return base::operator()();
+}
+
+// declarator:
+//  ptr_declarator
+//  noptr_declarator parameters_and_qualifiers trailing_return_type
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> Declarator<TagName>::operator()() {
+  return base::operator()();
+}
+
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> PtrDeclarator<TagName>::operator()() {
+  return base::operator()();
+}
+
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> NoptrDeclarator<TagName>::operator()() {
+  return base::operator()();
+}
+
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> ParametersAndQualifiers<TagName>::operator()() {
+  return base::operator()();
+}
+
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> TrailingReturnType<TagName>::operator()() {
+  return base::operator()();
+}
+
+}  // namespace lps::parser::details

--- a/include/parser/function.h
+++ b/include/parser/function.h
@@ -1,0 +1,377 @@
+/*
+* MIT License
+* Copyright (c) 2023 mxlol233 (mxlol233@outlook.com)
+
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+*LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#pragma once
+
+#include "parser.h"
+
+namespace lps::parser::details {
+
+template <meta::Str TagName, typename... ParseFuncs>
+class ParallelParseFunctions : public ParseFunction<TagName> {
+
+ public:
+  using base = ParseFunction<TagName>;
+  ParallelParseFunctions(const ParallelParseFunctions& other) = default;
+  explicit ParallelParseFunctions(const ParseFunctionInputs<TagName>& param,
+                                  ParseFuncs&&... funcs)
+      : base(param), parse_functions_(funcs...) {}
+  ParseFunctionOutputs<TagName> operator()() override {
+    ParseFunctionOutputs<TagName> output;
+
+    bool flg_continue = true;
+    std::apply(
+        [this, &flg_continue, &output](ParseFuncs&... funcs) {
+          (
+              [this, &flg_continue, &output](auto& func) {
+                if (flg_continue) {
+                  func.last_token(this->last_token());
+                  func.file_id(this->file_id());
+                  func.start(this->start());
+                  auto local_output = func();
+                  if (output.work_) {  // only allow one of them work
+                    flg_continue = false;
+                    output = local_output;
+                  } else {
+                    output.concat(std::move(local_output), false);
+                  }
+                }
+              }(funcs),
+              ...);
+        },
+        parse_functions_);
+    return output;
+  }
+
+ protected:
+  std::tuple<ParseFuncs...> parse_functions_;
+};
+
+template <meta::Str TagName, typename... ParseFuncs>
+class SerialParseFunctions : public ParseFunction<TagName> {
+
+ public:
+  using base = ParseFunction<TagName>;
+  SerialParseFunctions(const SerialParseFunctions& other) = default;
+  explicit SerialParseFunctions(const ParseFunctionInputs<TagName>& param,
+                                ParseFuncs&&... funcs)
+      : base(param), parse_functions_(funcs...) {}
+  ParseFunctionOutputs<TagName> operator()() override {
+    ParseFunctionOutputs<TagName> output;
+    token::Token<TagName + "_first_token"> tok;
+    output.last_token_ = this->last_token();
+    output.file_id_ = this->file_id();
+    output.start_ = this->start();
+
+    bool flg_continue = true;
+    std::apply(
+        [this, &flg_continue, &output](ParseFuncs&... funcs) {
+          (
+              [this, &flg_continue, &output](auto& func) {
+                if (flg_continue) {
+                  func.last_token(output.last_token_);
+                  func.file_id(output.file_id_);
+                  func.start(output.start_);
+                  auto local_output = func();
+                  if (!local_output.work_ && !func.opt()) {
+                    flg_continue = false;
+                  }
+                  output.concat(std::move(local_output), func.opt());
+                }
+              }(funcs),
+              ...);
+        },
+        parse_functions_);
+    return output;
+  }
+
+ protected:
+  std::tuple<ParseFuncs...> parse_functions_;
+};
+
+#define ParseFunctionDef(NAME)                                                \
+  template <meta::Str TagName = meta::S(#NAME)>                               \
+  class NAME : public ParseFunction<TagName> {                                \
+   public:                                                                    \
+    using base = ParseFunction<TagName>;                                      \
+    template <typename... Params>                                             \
+    explicit NAME(bool opt, Params... params) : base(opt, params...) {}       \
+    template <typename... Params>                                             \
+    explicit NAME(Params... params) : base(params...) {}                      \
+    explicit NAME(const ParseFunctionInputs<TagName>& param) : base(param) {} \
+    template <meta::Str TagNameOther>                                         \
+    explicit NAME(const ParseFunctionInputs<TagNameOther>& param)             \
+        : base(param) {}                                                      \
+    ParseFunctionOutputs<TagName> operator()() override;                      \
+  };
+
+ParseFunctionDef(TranslationUnit);
+ParseFunctionDef(DeclarationSeq);
+ParseFunctionDef(ModulePartition);
+ParseFunctionDef(AttributeSpecifierSeq);
+ParseFunctionDef(GlobalModuleFragment);
+ParseFunctionDef(ModuleDeclaration);
+ParseFunctionDef(PrivateModuleFragment);
+
+// ----------A.5 Expressions----------
+//expression:
+ParseFunctionDef(Expression);
+ParseFunctionDef(IdExpression);
+ParseFunctionDef(LambdaExpression);
+ParseFunctionDef(FoldExpression);
+ParseFunctionDef(RequiresExpression);
+
+// id-expression:
+ParseFunctionDef(UnqualifiedId);
+ParseFunctionDef(QualifiedId);
+
+// unqualified_id:
+ParseFunctionDef(Identifier);
+ParseFunctionDef(OperatorFunctionId);
+ParseFunctionDef(ConversionFunctionId);
+ParseFunctionDef(LiteralOperatorId);
+ParseFunctionDef(TypeName);
+ParseFunctionDef(DecltypeSpecifier);
+ParseFunctionDef(TemplateId);
+
+// qualified_id:
+ParseFunctionDef(NestedNameSpecifier);
+
+// nested_name_specifier:
+ParseFunctionDef(NamespaceName);
+ParseFunctionDef(SimpleTemplateId);
+
+// lambda_expression:
+ParseFunctionDef(LambdaIntroducer);
+ParseFunctionDef(LambdaDeclarator);
+ParseFunctionDef(CompoundStatement);
+ParseFunctionDef(TemplateParameterList);
+ParseFunctionDef(RequiresClause);
+
+// lambda_introducer:
+ParseFunctionDef(LambdaCapture);
+
+// lambda_declarator:
+ParseFunctionDef(ParameterDeclarationClause);
+ParseFunctionDef(DeclSpecifierSeq);
+ParseFunctionDef(NoexceptSpecifier);
+
+// lambda_capture:
+ParseFunctionDef(CaptureDefault);
+ParseFunctionDef(CaptureList);
+ParseFunctionDef(Capture);
+ParseFunctionDef(SimpleCapture);
+ParseFunctionDef(InitCapture);
+
+ParseFunctionDef(Initializer);
+
+// fold_expression:
+ParseFunctionDef(CastExpression);
+ParseFunctionDef(FoldOperator);
+
+// requires_expression:
+ParseFunctionDef(RequirementParameterList);
+ParseFunctionDef(RequirementBody);
+ParseFunctionDef(RequirementSeq);
+ParseFunctionDef(Requirement);
+
+// requirement:
+ParseFunctionDef(SimpleRequirement);
+ParseFunctionDef(TypeRequirement);
+ParseFunctionDef(CompoundRequirement);
+ParseFunctionDef(NestedRequirement);
+ParseFunctionDef(ReturnTypeRequirement);
+
+ParseFunctionDef(TypeConstraint);
+ParseFunctionDef(ConstraintExpression);
+
+ParseFunctionDef(TypeId);
+
+// postfix_expression:
+ParseFunctionDef(PostfixExpression);
+ParseFunctionDef(PrimaryExpression);
+ParseFunctionDef(ExprOrBracedInitList);
+ParseFunctionDef(ExpressionList);
+ParseFunctionDef(SimpleTypeSpecifier);
+ParseFunctionDef(TypenameSpecifier);
+ParseFunctionDef(BracedInitList);
+
+// expression-list:
+ParseFunctionDef(InitializerList);
+
+// unary_expression:
+ParseFunctionDef(UnaryExpression);
+ParseFunctionDef(UnaryOperator);
+ParseFunctionDef(AwaitExpression);
+ParseFunctionDef(NoexceptExpression);
+ParseFunctionDef(NewExpression);
+ParseFunctionDef(DeleteExpression);
+
+// new_expression:
+ParseFunctionDef(NewPlacement);
+ParseFunctionDef(NewTypeId);
+ParseFunctionDef(NewInitializer);
+ParseFunctionDef(TypeSpecifierSeq);
+ParseFunctionDef(PtrOperator);
+ParseFunctionDef(NoptrNewDeclarator);
+ParseFunctionDef(NewDeclarator);
+ParseFunctionDef(ConstantExpression);
+
+// pm_expression:
+ParseFunctionDef(PmExpression);
+
+// multiplicative_expression:
+ParseFunctionDef(MultiplicativeExpression);
+
+// additive_expression:
+ParseFunctionDef(AdditiveExpression);
+
+//shift_expression:
+ParseFunctionDef(ShiftExpression);
+
+// compare_expression:
+ParseFunctionDef(CompareExpression);
+
+// relational_expression:
+ParseFunctionDef(RelationalExpression);
+
+// equality-expression:
+ParseFunctionDef(EqualityExpression);
+
+// and-expression:
+ParseFunctionDef(AndExpression);
+
+// exclusive_or_expression:
+ParseFunctionDef(ExclusiveOrExpression);
+
+// inclusive-or-expression:
+ParseFunctionDef(InclusiveOrExpression);
+
+// logical_and_expression:
+ParseFunctionDef(LogicalAndExpression);
+
+// logical_and_expression:
+ParseFunctionDef(LogicalOrExpression);
+
+// conditional_expression:
+ParseFunctionDef(ConditionalExpression);
+ParseFunctionDef(AssignmentExpression);
+
+// yield_expression:
+ParseFunctionDef(YieldExpression);
+
+// throw_expression:
+ParseFunctionDef(ThrowExpression);
+
+// assignment_expression::
+ParseFunctionDef(AssignmentOperator);
+ParseFunctionDef(InitializerClause);
+
+// ----------A.6 Statements----------
+
+// statement:
+ParseFunctionDef(Statement);
+ParseFunctionDef(LabeledStatement);
+ParseFunctionDef(ExpressionStatement);
+ParseFunctionDef(SelectionStatement);
+ParseFunctionDef(IterationStatement);
+ParseFunctionDef(JumpStatement);
+ParseFunctionDef(DeclarationStatement);
+ParseFunctionDef(TryBlock);
+
+// init_statement:
+ParseFunctionDef(InitStatement);
+
+// condition:
+ParseFunctionDef(Condition);
+ParseFunctionDef(BraceOrEqualInitializer);
+
+ParseFunctionDef(StatementSeq);
+ParseFunctionDef(ForRangeDeclaration);
+ParseFunctionDef(ForRangeInitializer);
+ParseFunctionDef(RefQualifier);
+ParseFunctionDef(IdentifierList);
+ParseFunctionDef(CoroutineReturnStatement);
+
+// ----------A.7 Declarations----------
+
+// Declaration
+ParseFunctionDef(Declaration);
+
+ParseFunctionDef(BlockDeclaration);
+ParseFunctionDef(NodeclspecFunctionDeclaration);
+ParseFunctionDef(FunctionDefinition);
+ParseFunctionDef(TemplateDeclaration);
+ParseFunctionDef(DeductionGuide);
+ParseFunctionDef(ExplicitInstantiation);
+ParseFunctionDef(ExplicitSpecialization);
+ParseFunctionDef(ExportDeclaration);
+ParseFunctionDef(LinkageSpecification);
+ParseFunctionDef(NamespaceDefinition);
+ParseFunctionDef(EmptyDeclaration);
+ParseFunctionDef(AttributeDeclaration);
+ParseFunctionDef(ModuleImportDeclaration);
+
+// block_declaration:
+ParseFunctionDef(SimpleDeclaration);
+ParseFunctionDef(AsmDeclaration);
+ParseFunctionDef(NamespaceAliasDefinition);
+ParseFunctionDef(UsingDeclaration);
+ParseFunctionDef(UsingEnumDeclaration);
+ParseFunctionDef(UsingDirective);
+ParseFunctionDef(StaticAssertDeclaration);
+ParseFunctionDef(AliasDeclaration);
+ParseFunctionDef(OpaqueEnumDeclaration);
+
+// declarator:
+ParseFunctionDef(Declarator);
+ParseFunctionDef(PtrDeclarator);
+ParseFunctionDef(NoptrDeclarator);
+ParseFunctionDef(ParametersAndQualifiers);
+ParseFunctionDef(TrailingReturnType);
+
+ParseFunctionDef(DefiningTypeId);
+ParseFunctionDef(InitDeclaratorList);
+ParseFunctionDef(StringLiteral);
+
+// decl_specifier:
+ParseFunctionDef(DeclSpecifier);
+ParseFunctionDef(StorageClassSpecifier);
+ParseFunctionDef(DefiningTypeSpecifier);
+ParseFunctionDef(FunctionSpecifier);
+
+ParseFunctionDef(ExplicitSpecifier);
+
+// type-specifier:
+ParseFunctionDef(TypeSpecifier);
+ParseFunctionDef(ElaboratedTypeSpecifier);
+ParseFunctionDef(CvQualifier);
+
+// defining_type_specifier:
+ParseFunctionDef(DefiningTypeSpecifierSeq);
+ParseFunctionDef(ClassSpecifier);
+ParseFunctionDef(EnumSpecifier);
+
+#undef ParseFunctionDef
+
+}  // namespace lps::parser::details

--- a/include/parser/module.h
+++ b/include/parser/module.h
@@ -1,0 +1,181 @@
+/*
+* MIT License
+* Copyright (c) 2023 mxlol233 (mxlol233@outlook.com)
+
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+*LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#pragma once
+
+#include "parser/function.h"
+
+namespace lps::parser::details {
+
+// global_module_fragment:
+//  `module` `;` declaration-seq[opt]
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> GlobalModuleFragment<TagName>::operator()() {
+  auto output = base::operator()();
+  if (!this->valid()) {
+    return output;
+  }
+  auto cur_tok = this->params_.last_token_;
+
+  lexer::Lexer lexer(this->file_id(), this->start());
+  if (cur_tok.kind() == token::tok::TokenKind::kw_module) {
+
+    token::Token<meta::S("global_module_fragment_semi")> tok_semi;
+
+    if (tok_semi.kind() != token::tok::TokenKind::semi) {
+      if (!this->opt()) {
+        output.diag_record(diag::record<TagName>(
+            tok_semi, diag::DiagKind::global_module_expect_semi, cur_tok));
+      }
+
+      output.work_ = false;
+      return output;
+    }
+    {
+      output.last_token_ = tok_semi;
+      output.file_id_ = tok_semi.file_id();
+      output.start_ = lexer.cur();
+      output.work_ = true;
+    }
+    {
+      ParseFunctionInputs<TagName + "_serial_funcs"> a(
+          true, output.start_, output.file_id_,
+          token::Token<TagName + "_serial_funcs">(output.last_token_));
+      SerialParseFunctions serial_funcs(a, DeclarationSeq<>(true));
+
+      output.concat(serial_funcs(), true);
+    }
+  }
+
+  return output;
+}
+
+// module_declaration:
+//  `export`[opt] `module` module_name module_partition[opt] attribute_specifier_seq[opt] `;`
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> ModuleDeclaration<TagName>::operator()() {
+  auto output = base::operator()();
+  if (!this->valid()) {
+    return output;
+  }
+  auto cur_tok = this->params_.last_token_;
+
+  // `export`[opt] `module` module_name
+  {
+    lexer::Lexer lexer(this->file_id(), this->start());
+    // `export`[opt] `module`
+    {
+      token::Token<TagName + "_module_declaration"> tok;
+      tok = cur_tok;
+
+      // `export`[opt]
+      if (tok.kind() == token::tok::TokenKind::kw_export) {
+        lexer.lex(tok);
+      }
+
+      // `module`
+      if (tok.kind() != token::tok::TokenKind::kw_module) {
+        if (!this->opt()) {
+          output.diag_record(diag::record<TagName>(
+              tok, diag::DiagKind::module_decl_expect_kw_module));
+        }
+
+        output.work_ = false;
+        return output;
+      }
+    }
+
+    // module_name
+    {
+      token::Token<TagName + "_module_name"> tok;
+      lexer.lex(tok);
+      if (tok.kind() != token::tok::TokenKind::identifier) {
+        if (!this->opt()) {
+          output.diag_record(diag::record<TagName>(
+              tok, diag::DiagKind::module_decl_expect_ident));
+        }
+
+        output.work_ = false;
+        return output;
+      }
+
+      {
+        output.last_token_ = tok;
+        output.file_id_ = tok.file_id();
+        output.start_ = lexer.cur();
+      }
+    }
+  }
+
+  // module_partition[opt] attribute_specifier_seq[opt]
+  {
+    ParseFunctionInputs<TagName + "_serial_funcs"> a(
+        true, output.start_, output.file_id_,
+        token::Token<TagName + "_serial_funcs">(output.last_token_));
+    SerialParseFunctions serial_funcs(a, ModulePartition<>(true),
+                                      AttributeSpecifierSeq<>(true));
+
+    output.concat(serial_funcs(), true);
+  }
+
+  {
+    lexer::Lexer lexer(output.file_id_, output.start_);
+    token::Token<TagName + "_semi"> tok;
+    lexer.lex(tok);
+    if (tok.kind() != token::tok::TokenKind::semi) {
+      if (!this->opt()) {
+        output.diag_record(diag::record<TagName>(
+            tok, diag::DiagKind::global_module_expect_semi,
+            output.last_token_));
+      }
+
+      output.work_ = false;
+      return output;
+    }
+
+    {
+      output.last_token_ = tok;
+      output.file_id_ = tok.file_id();
+      output.start_ = lexer.cur();
+      output.work_ = true;
+    }
+    return output;
+  }
+}
+
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> ModulePartition<TagName>::operator()() {
+  return base::operator()();
+}
+
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> PrivateModuleFragment<TagName>::operator()() {
+  return base::operator()();
+}
+
+template <meta::Str TagName>
+ParseFunctionOutputs<TagName> AttributeSpecifierSeq<TagName>::operator()() {
+  return base::operator()();
+}
+
+}  // namespace lps::parser::details

--- a/include/token.h
+++ b/include/token.h
@@ -49,6 +49,11 @@ class Location {
     this->offset_id_ = other.offset();
     return *this;
   }
+  Location& operator=(const Location& other) {
+    this->file_id_ = other.file_id();
+    this->offset_id_ = other.offset();
+    return *this;
+  }
   template <meta::Str OtherTagName>
   explicit Location(const Location<OtherTagName>& other) {
     this->file_id_ = other.file_id();
@@ -158,6 +163,12 @@ struct Token : virtual public basic::mem::TraceTag<TagName> {
     SET(this, other);
     return *this;
   }
+
+  Token& operator=(const Token& other) {
+    SET(this, other);
+    return *this;
+  }
+
   Token() {}
   Token(const Token& other) {
     SET(this, other);


### PR DESCRIPTION
This week, I envisioned  to automatically implement  the parse function with a python script. Considering that all syntax definitions (https://timsong-cpp.github.io/cppwp/n4868/gram) can be disassembled into a parallel or serial parse function, this idea should make sense. I spent three days translating the c++ syntax definitions into a `dict` in python (`config.py`). `create_parse_functions.py` will do the auto-generated task based on the `dict`.